### PR TITLE
Revert 84fe24d4.

### DIFF
--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -320,7 +320,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         out = b''
         while True:
             try:
-                current = reader().encode('ascii')
+                current = reader()
             except timeout_exception:
                 return out, constants.StatusCode.error_timeout
 


### PR DESCRIPTION
Revert 84fe24d4.
With this code transfering binary data is not possible. Tested on both python 2.7 and python 3.4.
