### PR TITLE
Resolved the problems with binary gpib reads in python3

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -123,7 +123,7 @@ class GPIBSession(Session):
         # 0x2000 = 8192 = END
         checker = lambda current: self.interface.ibsta() & 8192
 
-        reader = lambda: self.interface.read(1)
+        reader = lambda: bytes([ord(self.interface.read(1))])
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -288,11 +288,11 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         Corresponds to viRead function of the VISA library.
 
         :param reader: Function to read one or more bytes.
-        :type reader: () -> str
+        :type reader: () -> byte
         :param count: Number of bytes to be read.
         :type count: int
         :param end_indicator_checker: Function to check if the message is complete.
-        :type end_indicator_checker: (str) -> boolean
+        :type end_indicator_checker: (byte) -> boolean
         :param suppress_end_en: suppress end.
         :type suppress_end_en: bool
         :param termination_char: Stop reading if this character is received.
@@ -320,7 +320,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         out = b''
         while True:
             try:
-                current = reader().encode('ascii')
+                current = reader()
             except timeout_exception:
                 return out, constants.StatusCode.error_timeout
 


### PR DESCRIPTION
The basic problem seems to be in the python binding for linux-gpib whihc return a string instead of a bytes array. The bottom solution works, but is in my opinion not very pretty. Multi-byte reading could/should probably be solved in the gpib module itself. 
