### PR TITLE
Fixed a bug where encode() was being called on a byte array

### DIFF
--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -320,7 +320,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         out = b''
         while True:
             try:
-                current = reader().encode('ascii')
+                current = reader()
             except timeout_exception:
                 return out, constants.StatusCode.error_timeout
 


### PR DESCRIPTION
`reader()` returns a byte array, so calling `reader().encode('ascii')` resulted in an error, which was fixed by simply removing the call to `encode()`.
