### PR TITLE
Use repr() instead of str() for logging the RPC record

### DIFF
--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -293,7 +293,7 @@ def sendfrag(sock, last, frag):
 
 
 def sendrecord(sock, record):
-    logger.debug('Sending record through %s: %s', sock, record)
+    logger.debug('Sending record through %s: %r', sock, record)
     sendfrag(sock, 1, record)
 
 


### PR DESCRIPTION
On Python 2.7 the str() representation of the record can't be printed to the terminal it isn't in utf-8 mode.
This will cause "UnicodeDecodeError: 'ascii' codec can't decode byte" errors to be printed, instead of the log message.
Use %r to format the record instead, in order to avoid this problem.