### PR TITLE
TCPIP error handling fixes: bis of #85

### DIFF
--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -162,7 +162,8 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
     # noinspection PyShadowingBuiltins
     def open(self, session, resource_name,
-             access_mode=constants.AccessModes.no_lock, open_timeout=constants.VI_TMO_IMMEDIATE):
+             access_mode=constants.AccessModes.no_lock,
+             open_timeout=constants.VI_TMO_IMMEDIATE):
         """Opens a session to the specified resource.
 
         Corresponds to viOpen function of the VISA library.
@@ -250,9 +251,14 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         # from the session handle, dispatch to the read method of the session object.
         try:
-            return self.sessions[session].read(count)
+            ret = self.sessions[session].read(count)
         except KeyError:
-            return constants.StatusCode.error_invalid_object
+            return 0, constants.StatusCode.error_invalid_object
+
+        if ret[1] < 0:
+            raise errors.VisaIOError(ret[1])
+
+        return ret
 
     def write(self, session, data):
         """Writes data to device or interface synchronously.
@@ -268,9 +274,14 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         # from the session handle, dispatch to the write method of the session object.
         try:
-            return self.sessions[session].write(data)
+            ret = self.sessions[session].write(data)
         except KeyError:
-            return constants.StatusCode.error_invalid_object
+            return 0, constants.StatusCode.error_invalid_object
+
+        if ret[1] < 0:
+            raise errors.VisaIOError(ret[1])
+
+        return ret
 
     def get_attribute(self, session, attribute):
         """Retrieves the state of an attribute.
@@ -315,4 +326,3 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
     def discard_events(self, session, event_type, mechanism):
         # TODO: implement this for GPIB finalization
         pass
-

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -87,14 +87,14 @@ class Vxi11Packer(rpc.Packer):
 
     def pack_device_link(self, link):
         self.pack_int(link)
-    
+
     def pack_create_link_parms(self, params):
         id, lock_device, lock_timeout, device = params
         self.pack_int(id)
         self.pack_bool(lock_device)
         self.pack_uint(lock_timeout)
         self.pack_string(device.encode('ascii'))
-    
+
     def pack_device_write_parms(self, params):
         link, io_timeout, lock_timeout, flags, data = params
         self.pack_int(link)
@@ -102,7 +102,7 @@ class Vxi11Packer(rpc.Packer):
         self.pack_uint(lock_timeout)
         self.pack_int(flags)
         self.pack_opaque(data)
-    
+
     def pack_device_read_parms(self, params):
         link, request_size, io_timeout, lock_timeout, flags, term_char = params
         self.pack_int(link)
@@ -111,14 +111,14 @@ class Vxi11Packer(rpc.Packer):
         self.pack_uint(lock_timeout)
         self.pack_int(flags)
         self.pack_int(term_char)
-    
+
     def pack_device_generic_parms(self, params):
         link, flags, lock_timeout, io_timeout = params
         self.pack_int(link)
         self.pack_int(flags)
         self.pack_uint(lock_timeout)
         self.pack_uint(io_timeout)
-    
+
     def pack_device_remote_func_parms(self, params):
         host_addr, host_port, prog_num, prog_vers, prog_family = params
         self.pack_uint(host_addr)
@@ -126,7 +126,7 @@ class Vxi11Packer(rpc.Packer):
         self.pack_uint(prog_num)
         self.pack_uint(prog_vers)
         self.pack_int(prog_family)
-    
+
     def pack_device_enable_srq_parms(self, params):
         link, enable, handle = params
         self.pack_int(link)
@@ -134,13 +134,13 @@ class Vxi11Packer(rpc.Packer):
         if len(handle) > 40:
             raise Vxi11Error("array length too long")
         self.pack_opaque(handle)
-    
+
     def pack_device_lock_parms(self, params):
         link, flags, lock_timeout = params
         self.pack_int(link)
         self.pack_int(flags)
         self.pack_uint(lock_timeout)
-    
+
     def pack_device_docmd_parms(self, params):
         link, flags, io_timeout, lock_timeout, cmd, network_order, datasize, data_in = params
         self.pack_int(link)
@@ -156,33 +156,33 @@ class Vxi11Packer(rpc.Packer):
 class Vxi11Unpacker(rpc.Unpacker):
     def unpack_device_link(self):
         return self.unpack_int()
-    
+
     def unpack_device_error(self):
         return self.unpack_int()
-    
+
     def unpack_create_link_resp(self):
         error = self.unpack_int()
         link = self.unpack_int()
         abort_port = self.unpack_uint()
         max_recv_size = self.unpack_uint()
         return error, link, abort_port, max_recv_size
-    
+
     def unpack_device_write_resp(self):
         error = self.unpack_int()
         size = self.unpack_uint()
         return error, size
-    
+
     def unpack_device_read_resp(self):
         error = self.unpack_int()
         reason = self.unpack_int()
         data = self.unpack_opaque()
         return error, reason, data
-    
+
     def unpack_device_read_stb_resp(self):
         error = self.unpack_int()
         stb = self.unpack_uint()
         return error, stb
-    
+
     def unpack_device_docmd_resp(self):
         error = self.unpack_int()
         data_out = self.unpack_opaque()
@@ -271,20 +271,14 @@ class CoreClient(rpc.TCPClient):
         return self.make_call(DESTROY_LINK, link,
                               self.packer.pack_device_link,
                               self.unpacker.unpack_device_error)
-    
+
     def create_intr_chan(self, host_addr, host_port, prog_num, prog_vers, prog_family):
         params = (host_addr, host_port, prog_num, prog_vers, prog_family)
         return self.make_call(CREATE_INTR_CHAN, params,
                               self.packer.pack_device_docmd_parms,
                               self.unpacker.unpack_device_error)
-    
+
     def destroy_intr_chan(self):
         return self.make_call(DESTROY_INTR_CHAN, None,
                               None,
                               self.unpacker.unpack_device_error)
-
-
-
-
-
-

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -15,10 +15,10 @@ import socket
 import select
 import time
 
-from pyvisa import constants, attributes
+from pyvisa import constants, attributes, errors
 
 from .sessions import Session, UnknownAttribute
-from .protocols import vxi11
+from .protocols import vxi11, rpc
 from . import common
 
 
@@ -35,7 +35,6 @@ class TCPIPInstrSession(Session):
     lock_timeout = 1000
     timeout = 1000
     client_id = None
-
     link = None
     max_recv_size = 1024
 
@@ -53,10 +52,8 @@ class TCPIPInstrSession(Session):
         self.timeout = 10000
         self.client_id = random.getrandbits(31)
 
-        (error, link,
-         abort_port,
-         max_recv_size) = self.interface.create_link(self.client_id, 0, self.lock_timeout,
-                                                     self.parsed.lan_device_name)
+        error, link, abort_port, max_recv_size = self.interface.create_link(
+            self.client_id, 0, self.lock_timeout, self.parsed.lan_device_name)
 
         if error:
             raise Exception("error creating link: %d" % error)
@@ -69,7 +66,11 @@ class TCPIPInstrSession(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def close(self):
-        self.interface.destroy_link(self.link)
+        try:
+            self.interface.destroy_link(self.link)
+        except (errors.VisaIOError, socket.error, rpc.RPCError) as e:
+            print("Error closing VISA link: {}".format(e))
+
         self.interface.close()
         self.link = None
         self.interface = None
@@ -88,32 +89,27 @@ class TCPIPInstrSession(Session):
         else:
             chunk_length = self.max_recv_size
 
-        flags = 0
-        reason = 0
-
         if self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)[0]:
             term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
-        else:
-            term_char = 0
-
-        if term_char:
-            flags = vxi11.OP_FLAG_TERMCHAR_SET
             term_char = str(term_char).encode('utf-8')[0]
+            flags = vxi11.OP_FLAG_TERMCHAR_SET
+        else:
+            term_char = flags = 0
 
         read_data = bytearray()
-
+        reason = 0
         end_reason = vxi11.RX_END | vxi11.RX_CHR
-
         read_fun = self.interface.device_read
-
         status = SUCCESS
 
         while reason & end_reason == 0:
             error, reason, data = read_fun(self.link, chunk_length, self.timeout,
                                            self.lock_timeout, flags, term_char)
 
-            if error:
-                return read_data, StatusCode.error_io
+            if error == vxi11.ErrorCodes.io_timeout:
+                return bytes(read_data), StatusCode.error_timeout
+            elif error:
+                return bytes(read_data), StatusCode.error_io
 
             read_data.extend(data)
             count -= len(data)
@@ -138,37 +134,37 @@ class TCPIPInstrSession(Session):
         """
 
         send_end, _ = self.get_attribute(constants.VI_ATTR_SEND_END_EN)
-
         chunk_size = 1024
-        try:
 
+        try:
             if send_end:
                 flags = vxi11.OP_FLAG_TERMCHAR_SET
             else:
                 flags = 0
 
             num = len(data)
-
             offset = 0
 
             while num > 0:
                 if num <= chunk_size:
                     flags |= vxi11.OP_FLAG_END
 
-                block = data[offset:offset+self.max_recv_size]
+                block = data[offset:offset + self.max_recv_size]
 
-                error, size = self.interface.device_write(self.link, self.timeout,
-                                                          self.lock_timeout, flags, block)
+                error, size = self.interface.device_write(
+                    self.link, self.timeout, self.lock_timeout, flags, block)
 
-                if error:
-                    return offset, StatusCode.error_io
-                elif size < len(block):
+                if error == vxi11.ErrorCodes.io_timeout:
+                    return offset, StatusCode.error_timeout
+
+                elif error or size < len(block):
                     return offset, StatusCode.error_io
 
                 offset += size
                 num -= size
 
             return offset, SUCCESS
+
         except vxi11.Vxi11Error:
             return 0, StatusCode.error_timeout
 
@@ -228,9 +224,8 @@ class TCPIPInstrSession(Session):
         :rtype: VISAStatus
         """
 
-        flags = 0
-
-        error = self.interface.device_trigger(self.link, flags, self.lock_timeout, self.io_timeout)
+        error = self.interface.device_trigger(self.link, 0, self.lock_timeout,
+                                              self.io_timeout)
 
         if error:
             # TODO: Which status to return
@@ -247,13 +242,14 @@ class TCPIPInstrSession(Session):
         :rtype: VISAStatus
         """
 
-        flags = 0
-
-        error = self.interface.device_clear(self.link, flags, self.lock_timeout, self.io_timeout)
+        error = self.interface.device_clear(self.link, 0, self.lock_timeout,
+                                            self.io_timeout)
 
         if error:
             # TODO: Which status to return
             raise Exception("error clearing: %d" % error)
+
+        return SUCCESS
 
     def read_stb(self):
         """Reads a status byte of the service request.
@@ -263,9 +259,10 @@ class TCPIPInstrSession(Session):
         :return: Service request status byte, return value of the library call.
         :rtype: int, VISAStatus
         """
-        flags = 0
 
-        error, stb = self.interface.device_read_stb(self.link, flags, self.lock_timeout, self.io_timeout)
+        error, stb = self.interface.device_read_stb(self.link, 0,
+                                                    self.lock_timeout,
+                                                    self.io_timeout)
 
         if error:
             # TODO: Which status to return
@@ -303,8 +300,6 @@ class TCPIPInstrSession(Session):
         :return: return value of the library call.
         :rtype: VISAStatus
         """
-        flags = 0
-
         error = self.interface.device_unlock(self.link)
 
         if error:
@@ -428,7 +423,7 @@ class TCPIPSocketSession(Session):
 
         while num > 0:
 
-            block = data[offset:min(offset+chunk_size, sz)]
+            block = data[offset:min(offset + chunk_size, sz)]
 
             try:
                 # use select to wait for write ready


### PR DESCRIPTION
This is #85 in which I simply took care of the merge conflicts ("" strings vs '' strings). This had already been reviewed several months ago and accepted. If nobody triggers this week-end I will do it on monday.

Added error handling for VisaIOErrors, raised with the appropriate error code.
Added error handling for socket.timeout, raised when the TCPIP-connected instrument stops responding. This could be due to a network issue or app crash, but it covers the case where the socket is left open but no communication is happening.
Minor code cleanup, removing unnecessary .split() functions for example.