### PR TITLE
Fix of #75 - unexpected keyword argument 'writeTimeout'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,8 @@ It depends on the interface type. For **ASRL** and **USB** we use PySerial_ and 
 respectively. For **TCPIP** we use the :py:mod:`socket` module in the Python Standard Library.
 **GPIB** resources are not currently supported but they are in the plan using `linux-gpib`_.
 
+PySerial_ version 3.0 or newer is required.
+
 
 If I only need **TCPIP**, do I need to install PySerial and PyUSB?
 ------------------------------------------------------------------

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -65,7 +65,7 @@ class SerialSession(Session):
         else:
             cls = Serial
 
-        self.interface = cls(port=self.parsed.board, timeout=2000, writeTimeout=2000)
+        self.interface = cls(port=self.parsed.board, timeout=2000, write_timeout=2000)
 
         for name in ('ASRL_END_IN', 'ASRL_END_OUT', 'SEND_END_EN', 'TERMCHAR',
                     'TERMCHAR_EN', 'SUPPRESS_END_EN'):
@@ -93,7 +93,7 @@ class SerialSession(Session):
             value = value / 1000.
 
         self.interface.timeout = value
-        self.interface.writeTimeout = value
+        self.interface.write_timeout = value
 
     def close(self):
         self.interface.close()

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -23,7 +23,7 @@ try:
     from serial.tools.list_ports import comports
 except ImportError as e:
     Session.register_unavailable(constants.InterfaceType.asrl, 'INSTR',
-                                 'Please install PySerial to use this resource type.\n%s' % e)
+                                 'Please install PySerial (>=3.0) to use this resource type.\n%s' % e)
 
     raise
 


### PR DESCRIPTION
writeTimeout renamed to write_timeout for pyserial.Serial class

Fixes #75
Fix is taken from #76 

name of parameter was changed in version 3.0 of pyserial package. pyserial 3.1 reverted writeTimeout to be again supported.


