### PR TITLE
TCPIP timeout handling improvement

### DIFF
--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -371,7 +371,6 @@ class TCPIPSocketSession(Session):
 
         read_fun = self.interface.recv
 
-        now = start = time.time()
 
         out = self._pending_buffer
 
@@ -383,7 +382,9 @@ class TCPIPSocketSession(Session):
 
         # initial 'select_timout' is same as timeout or max 2s, so when no data arrived then max block time
         select_timout = min(timeout, 2.0)
-        while now - start <= timeout:
+        # time, when loop shall finish
+        finish_time = time.time() + timeout
+        while time.time() <= finish_time:
             # use select to wait for read ready, max `select_timout` seconds
             r, w, x = select.select([self.interface], [], [], select_timout)
 
@@ -395,7 +396,6 @@ class TCPIPSocketSession(Session):
                 # can't read chunk or timeout
                 # `select_timout` decreased to 0.01 sec
                 select_timout = 0.01
-                now = time.time()
                 continue
 
             if enabled and end_byte in last:

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -394,8 +394,8 @@ class TCPIPSocketSession(Session):
 
             if not last:
                 # can't read chunk or timeout
-                # `select_timout` decreased to 0.01 sec
-                select_timout = 0.01
+                # `select_timout` decreased to 20% of previous, min wait time is 100ms
+                select_timout = max(select_timout/5.0, 0.1)
                 continue
 
             if enabled and end_byte in last:

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -382,11 +382,13 @@ class TCPIPSocketSession(Session):
 
         # initial 'select_timout' is half of timeout or max 2 secs, so when no data arrived then this is max block time
         select_timout = min(timeout/2.0, 2.0)
+        # minimum select timeout not to have too short select interval (minimum is 1 - 100ms)
+        min_select_timeout = max(min(select_timeout/10.0, 0.01), 0.001)
         # time, when loop shall finish
         finish_time = time.time() + timeout
         while time.time() <= finish_time:
-            # use select to wait for read ready, max `select_timout` seconds, min is 50ms
-            r, w, x = select.select([self.interface], [], [], max(select_timout, 0.05))
+            # use select to wait for read ready, max `select_timout` seconds, min is 'min_select_timeout' seconds
+            r, w, x = select.select([self.interface], [], [], max(select_timout, min_select_timeout))
 
             last = b''
             if self.interface in r:

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -383,7 +383,10 @@ class TCPIPSocketSession(Session):
             return (out + parts[0] + end_byte,
                     constants.StatusCode.success_termination_character_read)
 
-        # minimum select timeout not to have too short select interval (minimum is in interval 1 - 100ms based on timeout)
+        # On Windows, select is not interrupted by KeyboardInterrupt, to
+        # avoid blocking for very long time, we use a decreasing timeout
+        # in select
+        # minimum select timeout to avoid too short select interval (minimum is in interval 1 - 100ms based on timeout)
         min_select_timeout = max(min(timeout/100.0, 0.1), 0.001)
         # initial 'select_timout' is half of timeout or max 2 secs (max blocking time). min is from 'min_select_timeout'
         select_timout = max(min(timeout/2.0, 2.0), min_select_timeout)

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -394,7 +394,7 @@ class TCPIPSocketSession(Session):
 
             if not last:
                 # can't read chunk or timeout
-                # `select_timout` decreased to 50% of previous, min wait time is 100ms
+                # `select_timout` decreased to 50% of previous
                 select_timout = select_timout/2.0
                 continue
 


### PR DESCRIPTION
Improvement of #107

Code is simplified in calculation when timeout elapsed. (removed variable now)

### _poll_ interval calculation is improved.
_Note: Poll interval is necessary on windows, because select is not 'broken' by signal. so waiting in select for example 10 seconds would block program for 10 seconds until signal (CTRL+C) processed. \
On linux there is no such issue with ._

poll_ interval is calculated as 50% of previous _poll_ interval (min is 50ms). \
Previous constant 10ms _poll_ interval could increase CPU utilization.

When merged, #61 can be closed