### PR TITLE
VI_ATTR_SUPPRESS_END_EN in TCPIP SOCKET

### DIFF
--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -340,6 +340,8 @@ class TCPIPSocketSession(Session):
         for name in ('TERMCHAR', 'TERMCHAR_EN', 'SUPPRESS_END_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
+        # to use default as ni visa driver (NI-VISA 15.0)
+        self.attrs[getattr(constants, 'VI_ATTR_SUPPRESS_END_EN')] = True
 
     def close(self):
         self.interface.close()

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -61,7 +61,7 @@ class TCPIPInstrSession(Session):
         self.link = link
         self.max_recv_size = min(max_recv_size, 2 ** 30)  # 1GB
 
-        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'SUPPRESS_END_EN'):
+        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
@@ -194,6 +194,9 @@ class TCPIPInstrSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_TCPIP_PORT:
+            raise NotImplementedError
+
+        elif attribute == constants.VI_ATTR_SUPPRESS_END_EN:
             raise NotImplementedError
 
         raise UnknownAttribute(attribute)

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -365,6 +365,7 @@ class TCPIPSocketSession(Session):
         enabled, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
         timeout, _ = self.get_attribute(constants.VI_ATTR_TMO_VALUE)
         timeout /= 1000.0
+        suppress_end_en, _ = self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
 
         end_byte = common.int_to_byte(end_char) if end_char else b''
 
@@ -392,6 +393,10 @@ class TCPIPSocketSession(Session):
 
             if not last:
                 # can't read chunk or timeout
+                if out and not suppress_end_en:
+                    # we have some data without termchar but no further expected
+                    return out, constants.StatusCode.success
+    
                 # `select_timout` decreased to 0.01 sec
                 select_timout = 0.01
                 now = time.time()

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -61,7 +61,7 @@ class TCPIPInstrSession(Session):
         self.link = link
         self.max_recv_size = min(max_recv_size, 2 ** 30)  # 1GB
 
-        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
+        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'SUPPRESS_END_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
@@ -194,9 +194,6 @@ class TCPIPInstrSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_TCPIP_PORT:
-            raise NotImplementedError
-
-        elif attribute == constants.VI_ATTR_SUPPRESS_END_EN:
             raise NotImplementedError
 
         raise UnknownAttribute(attribute)
@@ -340,7 +337,7 @@ class TCPIPSocketSession(Session):
         self.attrs[constants.VI_ATTR_TCPIP_PORT] = self.parsed.port
         self.attrs[constants.VI_ATTR_INTF_NUM] = self.parsed.board
 
-        for name in ('TERMCHAR', 'TERMCHAR_EN'):
+        for name in ('TERMCHAR', 'TERMCHAR_EN', 'SUPPRESS_END_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 


### PR DESCRIPTION
attribute is set and read in TCPIP SOCKET resource driver. It works similar to description in http://zone.ni.com/reference/en-XX/help/370131S-01/ni-visa/vi_attr_suppress_end_en/ :\
_On TCP/IP SOCKET sessions, if this attribute is set to VI_FALSE, if NI-VISA reads some data and then detects a pause in the arrival of data packets, it will terminate the read operation. On TCP/IP SOCKET sessions, this attribute defaults to VI_TRUE in NI-VISA._

relates to #109 