### PR TITLE
TCPIP SOCKET improvements

### DIFF
--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -189,7 +189,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         cls = sessions.Session.get_session_class(parsed.interface_type_const, parsed.resource_class)
 
-        sess = cls(session, resource_name, parsed)
+        sess = cls(session, resource_name, parsed, open_timeout)
 
         return self._register(sess), constants.StatusCode.success
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -161,7 +161,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
 
         cls._session_classes[(interface_type, resource_class)] = _internal
 
-    def __init__(self, resource_manager_session, resource_name, parsed=None):
+    def __init__(self, resource_manager_session, resource_name, parsed=None, open_timeout=None):
         if isinstance(resource_name, common.MockInterface):
             parsed = rname.parse_resource_name(resource_name.resource_name)
             parsed['mock'] = resource_name
@@ -170,6 +170,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
             parsed = rname.parse_resource_name(resource_name)
 
         self.parsed = parsed
+        self.open_timeout = open_timeout
 
         #: Used as a place holder for the object doing the lowlevel communication.
         self.interface = None

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -394,14 +394,14 @@ class TCPIPSocketSession(Session):
             # use select to wait for read ready, max `select_timout` seconds, min is 'min_select_timeout' seconds
             r, w, x = select.select([self.interface], [], [], select_timout)
 
-            last = b''
+            read_data = b''
             if self.interface in r:
-                last = read_fun(chunk_length)
+                read_data = read_fun(chunk_length)
 
-            if last:
-                out.extend(last)
+            if read_data:
+                out.extend(read_data)
 
-                if term_char_en and term_byte in last:
+                if term_char_en and term_byte in read_data:
                     term_byte_index = out.index(term_byte) + 1
                     self._pending_buffer = out[term_byte_index:]
                     return bytes(out[:term_byte_index]), constants.StatusCode.success_termination_character_read

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -381,12 +381,13 @@ class TCPIPSocketSession(Session):
             self._pending_buffer = out[term_byte_index:]
             return bytes(out[:term_byte_index]), constants.StatusCode.success_termination_character_read
 
-        # On Windows, select is not interrupted by KeyboardInterrupt, to
-        # avoid blocking for very long time, we use a decreasing timeout
-        # in select
-        # minimum select timeout to avoid too short select interval (minimum is in interval 1 - 100ms based on timeout)
+        # On Windows, select is not interrupted by KeyboardInterrupt, to avoid blocking
+        # for very long time, we use a decreasing timeout in select
+        # minimum select timeout to avoid too short select interval
+        # (minimum is in interval 1 - 100ms based on timeout)
         min_select_timeout = max(min(timeout/100.0, 0.1), 0.001)
-        # initial 'select_timout' is half of timeout or max 2 secs (max blocking time). min is from 'min_select_timeout'
+        # initial 'select_timout' is half of timeout or max 2 secs (max blocking time).
+        # min is from 'min_select_timeout'
         select_timout = max(min(timeout/2.0, 2.0), min_select_timeout)
         # time, when loop shall finish
         finish_time = time.time() + timeout

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -334,7 +334,9 @@ class TCPIPSocketSession(Session):
     def after_parsing(self):
         # TODO: board_number not handled
 
-        self._connect()
+        ret_status = self._connect()
+        if ret_status != constants.StatusCode.success:
+            raise Exception("could not connect: {0}".format(str(ret_status)))
 
         self.attrs[constants.VI_ATTR_TCPIP_ADDR] = self.parsed.host_address
         self.attrs[constants.VI_ATTR_TCPIP_PORT] = self.parsed.port

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -364,20 +364,20 @@ class TCPIPSocketSession(Session):
         else:
             chunk_length = self.max_recv_size
 
-        end_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
-        enabled, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
+        term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
+        term_char_en, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
         timeout, _ = self.get_attribute(constants.VI_ATTR_TMO_VALUE)
         timeout /= 1000.0
         suppress_end_en, _ = self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
 
-        end_byte = common.int_to_byte(end_char) if end_char else b''
+        end_byte = common.int_to_byte(term_char) if term_char else b''
 
         read_fun = self.interface.recv
 
 
         out = self._pending_buffer
 
-        if enabled and end_byte in out:
+        if term_char_en and end_byte in out:
             parts = out.split(end_byte)
             self._pending_buffer = b''.join(parts[1:])
             return (out + parts[0] + end_byte,
@@ -410,7 +410,7 @@ class TCPIPSocketSession(Session):
                 select_timout = max(select_timout/2.0, min_select_timeout)
                 continue
 
-            if enabled and end_byte in last:
+            if term_char_en and end_byte in last:
                 parts = last.split(end_byte)
                 self._pending_buffer = b''.join(parts[1:])
                 return (out + parts[0] + end_byte,

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -318,7 +318,7 @@ class TCPIPSocketSession(Session):
     max_recv_size = 4096
 
     # This buffer is used to store the bytes that appeared after termination char
-    _pending_buffer = b''
+    _pending_buffer = bytearray()
 
     @staticmethod
     def list_resources():
@@ -374,8 +374,8 @@ class TCPIPSocketSession(Session):
 
         read_fun = self.interface.recv
 
-
-        out = self._pending_buffer
+        out = bytearray()
+        out.extend(self._pending_buffer)
 
         if term_char_en and term_byte in out:
             term_byte_index = out.index(term_byte) + 1
@@ -409,7 +409,7 @@ class TCPIPSocketSession(Session):
                 select_timout = max(select_timout/2.0, min_select_timeout)
                 continue
 
-            out += last
+            out.extend(last)
 
             if term_char_en and term_byte in last:
                 term_byte_index = out.index(term_byte) + 1

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -365,12 +365,11 @@ class TCPIPSocketSession(Session):
             chunk_length = self.max_recv_size
 
         term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
+        term_byte = common.int_to_byte(term_char) if term_char else b''
         term_char_en, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
         timeout, _ = self.get_attribute(constants.VI_ATTR_TMO_VALUE)
         timeout /= 1000.0
         suppress_end_en, _ = self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
-
-        term_byte = common.int_to_byte(term_char) if term_char else b''
 
         read_fun = self.interface.recv
 

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -336,6 +336,7 @@ class TCPIPSocketSession(Session):
 
         ret_status = self._connect()
         if ret_status != constants.StatusCode.success:
+            self.close()
             raise Exception("could not connect: {0}".format(str(ret_status)))
 
         self.attrs[constants.VI_ATTR_TCPIP_ADDR] = self.parsed.host_address

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -370,17 +370,17 @@ class TCPIPSocketSession(Session):
         timeout /= 1000.0
         suppress_end_en, _ = self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
 
-        end_byte = common.int_to_byte(term_char) if term_char else b''
+        term_byte = common.int_to_byte(term_char) if term_char else b''
 
         read_fun = self.interface.recv
 
 
         out = self._pending_buffer
 
-        if term_char_en and end_byte in out:
-            parts = out.split(end_byte)
+        if term_char_en and term_byte in out:
+            parts = out.split(term_byte)
             self._pending_buffer = b''.join(parts[1:])
-            return (out + parts[0] + end_byte,
+            return (out + parts[0] + term_byte,
                     constants.StatusCode.success_termination_character_read)
 
         # On Windows, select is not interrupted by KeyboardInterrupt, to
@@ -410,10 +410,10 @@ class TCPIPSocketSession(Session):
                 select_timout = max(select_timout/2.0, min_select_timeout)
                 continue
 
-            if term_char_en and end_byte in last:
-                parts = last.split(end_byte)
+            if term_char_en and term_byte in last:
+                parts = last.split(term_byte)
                 self._pending_buffer = b''.join(parts[1:])
-                return (out + parts[0] + end_byte,
+                return (out + parts[0] + term_byte,
                         constants.StatusCode.success_termination_character_read)
 
             out += last

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -380,7 +380,7 @@ class TCPIPSocketSession(Session):
         if term_char_en and term_byte in out:
             term_byte_index = out.index(term_byte) + 1
             self._pending_buffer = out[term_byte_index:]
-            return out[:term_byte_index], constants.StatusCode.success_termination_character_read
+            return bytes(out[:term_byte_index]), constants.StatusCode.success_termination_character_read
 
         # On Windows, select is not interrupted by KeyboardInterrupt, to
         # avoid blocking for very long time, we use a decreasing timeout
@@ -414,14 +414,14 @@ class TCPIPSocketSession(Session):
             if term_char_en and term_byte in last:
                 term_byte_index = out.index(term_byte) + 1
                 self._pending_buffer = out[term_byte_index:]
-                return out[:term_byte_index], constants.StatusCode.success_termination_character_read
+                return bytes(out[:term_byte_index]), constants.StatusCode.success_termination_character_read
 
 
             if len(out) >= count:
                 self._pending_buffer = out[count:]
-                return out[:count], constants.StatusCode.success_max_count_read
+                return bytes(out[:count]), constants.StatusCode.success_max_count_read
         else:
-            return out, constants.StatusCode.error_timeout
+            return bytes(out), constants.StatusCode.error_timeout
 
     def write(self, data):
         """Writes data to device or interface synchronously.

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -353,15 +353,12 @@ class TCPIPSocketSession(Session):
         timeout = self.open_timeout / 1000.0 if self.open_timeout is not None else None
         try:
             self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            old_timeout = self.interface.gettimeout()
-            self.interface.settimeout(0)
-            self.interface.connect((self.parsed.host_address, int(self.parsed.port)))
-        except BlockingIOError as e:
-            pass
+            self.interface.setblocking(0)
+            self.interface.connect_ex((self.parsed.host_address, int(self.parsed.port)))
         except Exception as e:
             raise Exception("could not connect: {0}".format(str(e)))
         finally:
-            self.interface.settimeout(old_timeout)
+            self.interface.setblocking(1)
 
         # minimum is in interval 100 - 500ms based on timeout
         min_select_timeout = max(min(timeout/10.0, 0.5), 0.1)


### PR DESCRIPTION
* Connect uses open_timeout parameter to be timeouted (#88)
* Refactored read operation with improved timeout handling
* Read Uses bytearray and bytes instead of string - inspired by #50 
* Calculation of return data in read uses indexes
* Renamed some variables for better readability.
