### PR TITLE
Unified StatusCode usage

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -40,7 +40,6 @@ def _find_listeners():
 
 
 StatusCode = constants.StatusCode
-SUCCESS = StatusCode.success
 
 # linux-gpib timeout constants, in milliseconds. See self.timeout.
 TIMETABLE = (0, 1e-2, 3e-2, 1e-1, 3e-1, 1e0, 3e0, 1e1, 3e1, 1e2, 3e2, 1e3, 3e3,
@@ -146,7 +145,7 @@ class GPIBSession(Session):
         try:
             self.interface.write(data)
 
-            return SUCCESS
+            return StatusCode.success
 
         except gpib.GpibError:
             # 0x4000 = 16384 = TIMO
@@ -168,20 +167,20 @@ class GPIBSession(Session):
         if attribute == constants.VI_ATTR_GPIB_READDR_EN:
             # IbaREADDR 0x6
             # Setting has no effect in linux-gpib.
-            return self.interface.ask(6), SUCCESS
+            return self.interface.ask(6), StatusCode.success
 
         elif attribute == constants.VI_ATTR_GPIB_PRIMARY_ADDR:
             # IbaPAD 0x1
-            return self.interface.ask(1), SUCCESS
+            return self.interface.ask(1), StatusCode.success
 
         elif attribute == constants.VI_ATTR_GPIB_SECONDARY_ADDR:
             # IbaSAD 0x2
             # Remove 0x60 because National Instruments.
             sad = self.interface.ask(2)
             if self.interface.ask(2):
-                return self.interface.ask(2) - 96, SUCCESS
+                return self.interface.ask(2) - 96, StatusCode.success
             else:
-                return constants.VI_NO_SEC_ADDR, SUCCESS
+                return constants.VI_NO_SEC_ADDR, StatusCode.success
 
         elif attribute == constants.VI_ATTR_GPIB_REN_STATE:
             # I have no idea how to implement this.
@@ -190,23 +189,23 @@ class GPIBSession(Session):
         elif attribute == constants.VI_ATTR_GPIB_UNADDR_EN:
             # IbaUnAddr 0x1b
             if self.interface.ask(27):
-                return constants.VI_TRUE, SUCCESS
+                return constants.VI_TRUE, StatusCode.success
             else:
-                return constants.VI_FALSE, SUCCESS
+                return constants.VI_FALSE, StatusCode.success
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
             # IbaEndBitIsNormal 0x1a
             if self.interface.ask(26):
-                return constants.VI_TRUE, SUCCESS
+                return constants.VI_TRUE, StatusCode.success
             else:
-                return constants.VI_FALSE, SUCCESS
+                return constants.VI_FALSE, StatusCode.success
 
         elif attribute == constants.VI_ATTR_INTF_NUM:
             # IbaBNA 0x200
-            return self.interface.ask(512), SUCCESS
+            return self.interface.ask(512), StatusCode.success
 
         elif attribute == constants.VI_ATTR_INTF_TYPE:
-            return constants.InterfaceType.gpib, SUCCESS
+            return constants.InterfaceType.gpib, StatusCode.success
 
         raise UnknownAttribute(attribute)
 
@@ -226,7 +225,7 @@ class GPIBSession(Session):
             # Setting has no effect in linux-gpib.
             if isinstance(attribute_state, int):
                 self.interface.config(6, attribute_state)
-                return SUCCESS
+                return StatusCode.success
             else:
                 return StatusCode.error_nonsupported_attribute_state
 
@@ -234,7 +233,7 @@ class GPIBSession(Session):
             # IbcPAD 0x1
             if isinstance(attribute_state, int) and 0 <= attribute_state <= 30:
                 self.interface.config(1, attribute_state)
-                return SUCCESS
+                return StatusCode.success
             else:
                 return StatusCode.error_nonsupported_attribute_state
 
@@ -244,7 +243,7 @@ class GPIBSession(Session):
             if isinstance(attribute_state, int) and 0 <= attribute_state <= 30:
                 if self.interface.ask(2):
                     self.interface.config(2, attribute_state + 96)
-                    return SUCCESS
+                    return StatusCode.success
                 else:
                     return StatusCode.error_nonsupported_attribute
             else:
@@ -254,7 +253,7 @@ class GPIBSession(Session):
             # IbcUnAddr 0x1b
             try:
                 self.interface.config(27, attribute_state)
-                return SUCCESS
+                return StatusCode.success
             except gpib.GpibError:
                 return StatusCode.error_nonsupported_attribute_state
 
@@ -262,7 +261,7 @@ class GPIBSession(Session):
             # IbcEndBitIsNormal 0x1a
             if isinstance(attribute_state, int):
                 self.interface.config(26, attribute_state)
-                return SUCCESS
+                return StatusCode.success
             else:
                 return StatusCode.error_nonsupported_attribute_state
 

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -22,6 +22,7 @@ from pyvisa.compat import integer_types, OrderedDict
 from . import sessions
 from .common import logger
 
+StatusCode = constants.StatusCode
 
 class PyVisaLibrary(highlevel.VisaLibraryBase):
     """A pure Python backend for PyVISA.
@@ -122,7 +123,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
                      extra=self._logging_extra)
 
         try:
-            ret_value = constants.StatusCode(ret_value)
+            ret_value = StatusCode(ret_value)
         except ValueError:
             pass
 
@@ -185,13 +186,13 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         try:
             parsed = rname.parse_resource_name(resource_name)
         except rname.InvalidResourceName:
-            return 0, constants.StatusCode.error_invalid_resource_name
+            return 0, StatusCode.error_invalid_resource_name
 
         cls = sessions.Session.get_session_class(parsed.interface_type_const, parsed.resource_class)
 
         sess = cls(session, resource_name, parsed, open_timeout)
 
-        return self._register(sess), constants.StatusCode.success
+        return self._register(sess), StatusCode.success
 
     def close(self, session):
         """Closes the specified session, event, or find list.
@@ -207,7 +208,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             if sess is not self:
                 sess.close()
         except KeyError:
-            return constants.StatusCode.error_invalid_object
+            return StatusCode.error_invalid_object
 
     def open_default_resource_manager(self):
         """This function returns a session to the Default Resource Manager resource.
@@ -217,7 +218,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         :return: Unique logical identifier to a Default Resource Manager session, return value of the library call.
         :rtype: session, VISAStatus
         """
-        return self._register(self), constants.StatusCode.success
+        return self._register(self), StatusCode.success
 
     def list_resources(self, session, query='?*::INSTR'):
         """Returns a tuple of all connected devices matching query.
@@ -253,7 +254,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         try:
             ret = self.sessions[session].read(count)
         except KeyError:
-            return 0, constants.StatusCode.error_invalid_object
+            return 0, StatusCode.error_invalid_object
 
         if ret[1] < 0:
             raise errors.VisaIOError(ret[1])
@@ -276,7 +277,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         try:
             ret = self.sessions[session].write(data)
         except KeyError:
-            return 0, constants.StatusCode.error_invalid_object
+            return 0, StatusCode.error_invalid_object
 
         if ret[1] < 0:
             raise errors.VisaIOError(ret[1])
@@ -296,7 +297,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         try:
             sess = self.sessions[session]
         except KeyError:
-            return None, constants.StatusCode.error_invalid_object
+            return None, StatusCode.error_invalid_object
 
         return sess.get_attribute(attribute)
 
@@ -315,7 +316,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         try:
             sess = self.sessions[session]
         except KeyError:
-            return constants.StatusCode.error_invalid_object
+            return StatusCode.error_invalid_object
 
         return sess.set_attribute(attribute, attribute_state)
 

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -37,7 +37,6 @@ def to_state(boolean_input):
 
 
 StatusCode = constants.StatusCode
-SUCCESS = StatusCode.success
 SerialTermination = constants.SerialTermination
 
 
@@ -172,7 +171,7 @@ class SerialSession(Session):
                 logger.debug('Serial.sendBreak')
                 self.interface.sendBreak()
 
-            return count, constants.StatusCode.success
+            return count, StatusCode.success
 
         except serial.SerialTimeoutException:
             return 0, StatusCode.error_timeout
@@ -191,10 +190,10 @@ class SerialSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_ASRL_AVAIL_NUM:
-            return self.interface.inWaiting(), SUCCESS
+            return self.interface.inWaiting(), StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_BAUD:
-            return self.interface.baudrate, SUCCESS
+            return self.interface.baudrate, StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_BREAK_LEN:
             raise NotImplementedError
@@ -206,10 +205,10 @@ class SerialSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_ASRL_CTS_STATE:
-            return to_state(self.interface.getCTS()), SUCCESS
+            return to_state(self.interface.getCTS()), StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_DATA_BITS:
-            return self.interface.bytesize, SUCCESS
+            return self.interface.bytesize, StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_DCD_STATE:
             raise NotImplementedError
@@ -218,7 +217,7 @@ class SerialSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_ASRL_DSR_STATE:
-            return to_state(self.interface.getDSR()), SUCCESS
+            return to_state(self.interface.getDSR()), StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_DTR_STATE:
             raise NotImplementedError
@@ -226,20 +225,20 @@ class SerialSession(Session):
         elif attribute == constants.VI_ATTR_ASRL_FLOW_CNTRL:
             return (self.interface.xonxoff * constants.VI_ASRL_FLOW_XON_XOFF |
                     self.interface.rtscts * constants.VI_ASRL_FLOW_RTS_CTS |
-                    self.interface.dsrdtr * constants.VI_ASRL_FLOW_DTR_DSR), SUCCESS
+                    self.interface.dsrdtr * constants.VI_ASRL_FLOW_DTR_DSR), StatusCode.success
 
         elif attribute == constants.VI_ATTR_ASRL_PARITY:
             parity = self.interface.parity
             if parity == serial.PARITY_NONE:
-                return constants.Parity.none, SUCCESS
+                return constants.Parity.none, StatusCode.success
             elif parity == serial.PARITY_EVEN:
-                return constants.Parity.even, SUCCESS
+                return constants.Parity.even, StatusCode.success
             elif parity == serial.PARITY_ODD:
-                return constants.Parity.odd, SUCCESS
+                return constants.Parity.odd, StatusCode.success
             elif parity == serial.PARITY_MARK:
-                return constants.Parity.mark, SUCCESS
+                return constants.Parity.mark, StatusCode.success
             elif parity == serial.PARITY_SPACE:
-                return constants.Parity.space, SUCCESS
+                return constants.Parity.space, StatusCode.success
 
             raise Exception('Unknown parity value: %r' % parity)
 
@@ -252,11 +251,11 @@ class SerialSession(Session):
         elif attribute == constants.VI_ATTR_ASRL_STOP_BITS:
             bits = self.interface.stopbits
             if bits == serial.STOPBITS_ONE:
-                return constants.StopBits.one, SUCCESS
+                return constants.StopBits.one, StatusCode.success
             elif bits == serial.STOPBITS_ONE_POINT_FIVE:
-                return constants.StopBits.one_and_a_half, SUCCESS
+                return constants.StopBits.one_and_a_half, StatusCode.success
             elif bits == serial.STOPBITS_TWO:
-                return constants.StopBits.two, SUCCESS
+                return constants.StopBits.two, StatusCode.success
 
             raise Exception('Unknown bits value: %r' % bits)
 
@@ -264,7 +263,7 @@ class SerialSession(Session):
             raise NotImplementedError
 
         elif attribute == constants.VI_ATTR_INTF_TYPE:
-            return constants.InterfaceType.asrl, SUCCESS
+            return constants.InterfaceType.asrl, StatusCode.success
 
         raise UnknownAttribute(attribute)
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -20,6 +20,8 @@ from pyvisa import logger, constants, attributes, compat, rname
 from . import common
 
 
+StatusCode = constants.StatusCode
+
 class UnknownAttribute(Exception):
 
     def __init__(self, attribute):
@@ -203,11 +205,11 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         try:
             attr = attributes.AttributesByID[attribute]
         except KeyError:
-            return 0, constants.StatusCode.error_nonsupported_attribute
+            return 0, StatusCode.error_nonsupported_attribute
 
         # Check if the attribute is defined for this session type.
         if not attr.in_resource(self.session_type):
-            return 0, constants.StatusCode.error_nonsupported_attribute
+            return 0, StatusCode.error_nonsupported_attribute
 
         # Check if reading the attribute is allowed.
         if not attr.read:
@@ -216,10 +218,10 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         # First try to answer those attributes that are common to all session types
         # or user defined because they are not defined by the interface.
         if attribute in self.attrs:
-            return self.attrs[attribute], constants.StatusCode.success
+            return self.attrs[attribute], StatusCode.success
 
         elif attribute == constants.VI_ATTR_TMO_VALUE:
-            return self.timeout, constants.StatusCode.success
+            return self.timeout, StatusCode.success
 
         # Dispatch to `_get_attribute`, which must be implemented by subclasses.
 
@@ -227,7 +229,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
             return self._get_attribute(attribute)
         except UnknownAttribute as e:
             logger.exception(str(e))
-            return 0, constants.StatusCode.error_nonsupported_attribute
+            return 0, StatusCode.error_nonsupported_attribute
 
     def set_attribute(self, attribute, attribute_state):
         """Set the attribute_state value for a given VISA attribute for this session.
@@ -244,43 +246,43 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         try:
             attr = attributes.AttributesByID[attribute]
         except KeyError:
-            return constants.StatusCode.error_nonsupported_attribute
+            return StatusCode.error_nonsupported_attribute
 
         # Check if the attribute is defined for this session type.
         if not attr.in_resource(self.session_type):
-            return constants.StatusCode.error_nonsupported_attribute
+            return StatusCode.error_nonsupported_attribute
 
         # Check if writing the attribute is allowed.
         if not attr.write:
-            return constants.StatusCode.error_attribute_read_only
+            return StatusCode.error_attribute_read_only
 
         # First try to answer those attributes that are common to all session types
         # or user defined because they are not defined by the interface.
         if attribute in self.attrs:
             self.attrs[attribute] = attribute_state
-            return constants.StatusCode.success
+            return StatusCode.success
 
         elif attribute == constants.VI_ATTR_TMO_VALUE:
             try:
                 self.timeout = attribute_state
             except:
-                return constants.StatusCode.error_nonsupported_attribute_state
+                return StatusCode.error_nonsupported_attribute_state
 
-            return constants.StatusCode.success
+            return StatusCode.success
 
         # Dispatch to `_set_attribute`, which must be implemented by subclasses.
 
         try:
             return self._set_attribute(attribute, attribute_state)
         except ValueError:
-            return constants.StatusCode.error_nonsupported_attribute_state
+            return StatusCode.error_nonsupported_attribute_state
         except NotImplementedError:
             e = UnknownAttribute(attribute)
             logger.exception(str(e))
-            return constants.StatusCode.error_nonsupported_attribute
+            return StatusCode.error_nonsupported_attribute
         except UnknownAttribute as e:
             logger.exception(str(e))
-            return constants.StatusCode.error_nonsupported_attribute
+            return StatusCode.error_nonsupported_attribute
 
     def _read(self, reader, count, end_indicator_checker, suppress_end_en,
               termination_char, termination_char_en, timeout_exception):
@@ -323,7 +325,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
             try:
                 current = reader().encode('ascii')
             except timeout_exception:
-                return out, constants.StatusCode.error_timeout
+                return out, StatusCode.error_timeout
 
             if current:
                 out += current
@@ -331,16 +333,16 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                 if end_indicator_received:
                     if not suppress_end_en:
                         # RULE 6.1.1
-                        return out, constants.StatusCode.success
+                        return out, StatusCode.success
                 else:
                     if termination_char_en and termination_char in current:
                         # RULE 6.1.2
                         # Return everything upto and including the termination character
-                        return out[:out.index(termination_char)+1], constants.StatusCode.success_termination_character_read
+                        return out[:out.index(termination_char)+1], StatusCode.success_termination_character_read
                     elif len(out) >= count:
                         # RULE 6.1.3
                         # Return at most the number of bytes requested
-                        return out[:count], constants.StatusCode.success_max_count_read
+                        return out[:count], StatusCode.success_max_count_read
 
             if time.time() - start > timeout:
-                return out, constants.StatusCode.error_timeout
+                return out, StatusCode.error_timeout

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -23,7 +23,6 @@ from . import common
 
 
 StatusCode = constants.StatusCode
-SUCCESS = StatusCode.success
 
 
 @Session.register(constants.InterfaceType.tcpip, 'INSTR')
@@ -100,7 +99,7 @@ class TCPIPInstrSession(Session):
         reason = 0
         end_reason = vxi11.RX_END | vxi11.RX_CHR
         read_fun = self.interface.device_read
-        status = SUCCESS
+        status = StatusCode.success
 
         while reason & end_reason == 0:
             error, reason, data = read_fun(self.link, chunk_length, self.timeout,
@@ -163,7 +162,7 @@ class TCPIPInstrSession(Session):
                 offset += size
                 num -= size
 
-            return offset, SUCCESS
+            return offset, StatusCode.success
 
         except vxi11.Vxi11Error:
             return 0, StatusCode.error_timeout
@@ -179,7 +178,7 @@ class TCPIPInstrSession(Session):
         """
 
         if attribute == constants.VI_ATTR_TCPIP_ADDR:
-            return self.host_address, SUCCESS
+            return self.host_address, StatusCode.success
 
         elif attribute == constants.VI_ATTR_TCPIP_DEVICE_NAME:
             raise NotImplementedError
@@ -231,7 +230,7 @@ class TCPIPInstrSession(Session):
             # TODO: Which status to return
             raise Exception("error triggering: %d" % error)
 
-        return SUCCESS
+        return StatusCode.success
 
     def clear(self):
         """Clears a device.
@@ -249,7 +248,7 @@ class TCPIPInstrSession(Session):
             # TODO: Which status to return
             raise Exception("error clearing: %d" % error)
 
-        return SUCCESS
+        return StatusCode.success
 
     def read_stb(self):
         """Reads a status byte of the service request.
@@ -268,7 +267,7 @@ class TCPIPInstrSession(Session):
             # TODO: Which status to return
             raise Exception("error reading status: %d" % error)
 
-        return stb, SUCCESS
+        return stb, StatusCode.success
 
     def lock(self, lock_type, timeout, requested_key=None):
         """Establishes an access mode to the specified resources.
@@ -335,7 +334,7 @@ class TCPIPSocketSession(Session):
         # TODO: board_number not handled
 
         ret_status = self._connect()
-        if ret_status != constants.StatusCode.success:
+        if ret_status != StatusCode.success:
             self.close()
             raise Exception("could not connect: {0}".format(str(ret_status)))
 
@@ -371,11 +370,11 @@ class TCPIPSocketSession(Session):
             # use select to wait for socket ready, max `select_timout` seconds
             r, w, x = select.select([self.interface], [self.interface], [], select_timout)
             if self.interface in r or self.interface in w:
-                return constants.StatusCode.success
+                return StatusCode.success
 
             if time.time() >= finish_time:
                 # reached timeout
-                return constants.StatusCode.error_timeout
+                return StatusCode.error_timeout
 
             # `select_timout` decreased to 50% of previous or min_select_timeout
             select_timout = max(select_timout/2.0, min_select_timeout)
@@ -423,11 +422,11 @@ class TCPIPSocketSession(Session):
             if term_char_en and term_byte in out:
                 term_byte_index = out.index(term_byte) + 1
                 self._pending_buffer = out[term_byte_index:]
-                return bytes(out[:term_byte_index]), constants.StatusCode.success_termination_character_read
+                return bytes(out[:term_byte_index]), StatusCode.success_termination_character_read
 
             if len(out) >= count:
                 self._pending_buffer = out[count:]
-                return bytes(out[:count]), constants.StatusCode.success_max_count_read
+                return bytes(out[:count]), StatusCode.success_max_count_read
 
             # use select to wait for read ready, max `select_timout` seconds
             r, w, x = select.select([self.interface], [], [], select_timout)
@@ -442,12 +441,12 @@ class TCPIPSocketSession(Session):
                 if out and not suppress_end_en:
                     # we have some data without termchar but no further data expected
                     self._pending_buffer = out[count:]
-                    return bytes(out[:count]), constants.StatusCode.success
+                    return bytes(out[:count]), StatusCode.success
     
                 if time.time() >= finish_time:
                     # reached timeout
                     self._pending_buffer = out[count:]
-                    return bytes(out[:count]), constants.StatusCode.error_timeout
+                    return bytes(out[:count]), StatusCode.error_timeout
 
                 # `select_timout` decreased to 50% of previous or min_select_timeout
                 select_timout = max(select_timout/2.0, min_select_timeout)
@@ -486,7 +485,7 @@ class TCPIPSocketSession(Session):
             offset += size
             num -= size
 
-        return offset, SUCCESS
+        return offset, StatusCode.success
 
     def _get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -46,7 +46,6 @@ except Exception as e:
 from . import common
 
 StatusCode = constants.StatusCode
-SUCCESS = StatusCode.success
 
 class USBSession(Session):
     """Base class for drivers that communicate with usb devices
@@ -135,7 +134,7 @@ class USBSession(Session):
 
         count = self.interface.write(data)
 
-        return count, SUCCESS
+        return count, StatusCode.success
 
     def close(self):
         self.interface.close()


### PR DESCRIPTION
Code cosmetic refactoring:
* `StatusCode.<status_code>` replaces `constants.StatusCode.xxx`
* `StatusCode.success` replaces `SUCCESS`.

