### PR TITLE
Fix of encode called on bytes object

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -125,7 +125,7 @@ class GPIBSession(Session):
         # 0x2000 = 8192 = END
         checker = lambda current: self.interface.ibsta() & 8192
 
-        reader = lambda: self.interface.read(count)
+        reader = lambda: self.interface.read(count).encode('ascii')
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -323,7 +323,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         out = b''
         while True:
             try:
-                current = reader().encode('ascii')
+                current = reader()
             except timeout_exception:
                 return out, StatusCode.error_timeout
 


### PR DESCRIPTION
this is PR to fix PR #59 in gpib module and not in generic session when reader shall return bytes and not string. similar approach was provided in #70 (author @DavidFabijan )
It shall fix these issues: #69, #73,  

Problem in gpib  could be not solved perfectly, but is not spread across other session types.

This invalidates PRs: #66 (author @herm ) , #70 (@DavidFabijan ), #86 (@marekp0). All could be closed.

