### PR TITLE
TCPIP INSTR Session / RPC timeout handling improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,17 @@ branches:
     - master
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 
 install:
-  - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install unittest2; fi
-  - if [ $TRAVIS_PYTHON_VERSION == '3.2' ]; then pip install coverage==3.7.1; else pip install coverage; fi
+  - pip install coverage
   - pip install coveralls
 
 script:
-  - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then coverage run -p --source=pyvisa-py --omit="*test*" setup.py test; fi
-  - if [ $TRAVIS_PYTHON_VERSION != '2.6' ]; then python -bb -m coverage run -p --source=pyvisa-py --omit="*test*" setup.py test; fi
+  - python -bb -m coverage run -p --source=pyvisa-py --omit="*test*" setup.py test
   - coverage combine
   - coverage report -m
 

--- a/README
+++ b/README
@@ -38,7 +38,7 @@ Python has a couple of features that make it very interesting for measurement co
 Requirements
 ------------
 
-- Python (tested with 2.6 and 2.7, 3.2+)
+- Python (tested with 2.7, 3.4+)
 - PyVISA 1.6+
 
 Optionally

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,8 +86,9 @@ Now:
 Are all VISA attributes and methods implemented?
 ------------------------------------------------
 
-No. We have implemented those attributes and methods that are most commonly needed.
-We would like to reach feature parity. If there is something that you need, let us know.
+No. We have implemented those attributes and methods that are most commonly
+needed. We would like to reach feature parity. If there is something that you
+need, let us know.
 
 
 Why are you developing this?
@@ -100,9 +101,9 @@ We wanted to provide a compatible alternative.
 Why not using LibreVISA?
 ------------------------
 
-LibreVISA_ is still young. However, you can already use it with the NI backend as it
-has the same API. We think that PyVISA-py is easier to hack and we can quickly
-reach feature parity with NI-VISA for message-based instruments.
+LibreVISA_ is still young. However, you can already use it with the NI backend
+as it has the same API. We think that PyVISA-py is easier to hack and we can
+quickly reach feature parity with NI-VISA for message-based instruments.
 
 
 Why putting PyVISA in the middle?

--- a/pyvisa-py/common.py
+++ b/pyvisa-py/common.py
@@ -9,7 +9,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import logging
 import sys

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -294,7 +294,7 @@ def sendfrag(sock, last, frag):
     sock.send(header + frag)
 
 
-def _sendrecord(sock, record, fragsize = None, timeout = None):
+def _sendrecord(sock, record, fragsize=None, timeout=None):
     logger.debug('Sending record through %s: %r', sock, record)
     if timeout is not None:
         r, w, x = select.select([], [sock], [], timeout)
@@ -316,7 +316,7 @@ def _sendrecord(sock, record, fragsize = None, timeout = None):
         record = record[fragsize:]
 
 
-def _recvrecord(sock, timeout, read_fun = None):
+def _recvrecord(sock, timeout, read_fun=None):
 
     record = bytearray()
     buffer = bytearray()
@@ -373,7 +373,7 @@ def _recvrecord(sock, timeout, read_fun = None):
                     wait_header = True
                     exp_length = 4
 
-def _connect(sock, host, port, timeout = 0):
+def _connect(sock, host, port, timeout=0):
         try:
             sock.setblocking(0)
             sock.connect_ex((host, port))
@@ -407,7 +407,7 @@ def _connect(sock, host, port, timeout = 0):
 class RawTCPClient(Client):
     """Client using TCP to a specific port.
     """
-    def __init__(self, host, prog, vers, port, open_timeout = 5000):
+    def __init__(self, host, prog, vers, port, open_timeout=5000):
         Client.__init__(self, host, prog, vers, port)
         self.connect((open_timeout / 1000.0) + 1.0)
         # self.timeout defaults higher than the default 2 second VISA timeout,
@@ -664,7 +664,7 @@ class PartialPortMapperClient(object):
 
 class TCPPortMapperClient(PartialPortMapperClient, RawTCPClient):
 
-    def __init__(self, host, open_timeout = 5000):
+    def __init__(self, host, open_timeout=5000):
         RawTCPClient.__init__(self, host, PMAP_PROG, PMAP_VERS, PMAP_PORT, open_timeout)
         PartialPortMapperClient.__init__(self)
 
@@ -686,7 +686,7 @@ class BroadcastUDPPortMapperClient(PartialPortMapperClient, RawBroadcastUDPClien
 class TCPClient(RawTCPClient):
     """A TCP Client that find their server through the Port mapper
     """
-    def __init__(self, host, prog, vers, open_timeout = 5000):
+    def __init__(self, host, prog, vers, open_timeout=5000):
         pmap = TCPPortMapperClient(host, open_timeout)
         port = pmap.get_port((prog, vers, IPPROTO_TCP, 0))
         pmap.close()

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -446,7 +446,7 @@ class RawTCPClient(Client):
     def do_call(self):
         call = self.packer.get_buf()
 
-        _sendrecord(self.sock, call, timeout = self.timeout)
+        _sendrecord(self.sock, call, timeout=self.timeout)
 
         reply = _recvrecord(self.sock, self.timeout)
         u = self.unpacker

--- a/pyvisa-py/protocols/usbraw.py
+++ b/pyvisa-py/protocols/usbraw.py
@@ -77,11 +77,11 @@ class USBRawDevice(USBRaw):
 
         raw_read = super(USBRawDevice, self).read
 
-        received = b''
+        received = bytearray()
 
         while not len(received) >= size:
             resp = raw_read(self.RECV_CHUNK)
 
-            received += resp
+            received.extend(resp)
 
-        return received
+        return bytes(received)

--- a/pyvisa-py/protocols/usbraw.py
+++ b/pyvisa-py/protocols/usbraw.py
@@ -18,18 +18,18 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 
 from .usbtmc import USBRaw as USBRaw
 
-import usb
-
-from .usbutil import find_devices, find_interfaces, find_endpoint, usb_find_desc
+from .usbutil import find_devices, find_interfaces
 
 
-def find_raw_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_raw_devices(vendor=None, product=None, serial_number=None,
+                     custom_match=None, **kwargs):
     """Find connected USB RAW devices. See usbutil.find_devices for more info.
     """
     def is_usbraw(dev):
         if custom_match and not custom_match(dev):
             return False
-        return bool(find_interfaces(dev, bInterfaceClass=0xFF, bInterfaceSubClass=0xFF))
+        return bool(find_interfaces(dev, bInterfaceClass=0xFF,
+                                    bInterfaceSubClass=0xFF))
 
     return find_devices(vendor, product, serial_number, is_usbraw, **kwargs)
 
@@ -66,7 +66,6 @@ class USBRawDevice(USBRaw):
 
         return bytes_sent
 
-
     def read(self, size):
         """Read raw bytes from the instrument.
 
@@ -77,7 +76,6 @@ class USBRawDevice(USBRaw):
         """
 
         raw_read = super(USBRawDevice, self).read
-        raw_write = super(USBRawDevice, self).write
 
         received = b''
 

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -58,13 +58,16 @@ class Request(enum.IntEnum):
     indicator_pulse = 64
 
 
-def find_tmc_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_tmc_devices(vendor=None, product=None, serial_number=None,
+                     custom_match=None, **kwargs):
     """Find connected USBTMC devices. See usbutil.find_devices for more info.
+
     """
     def is_usbtmc(dev):
         if custom_match and not custom_match(dev):
             return False
-        return bool(find_interfaces(dev, bInterfaceClass=0xfe, bInterfaceSubClass=3))
+        return bool(find_interfaces(dev, bInterfaceClass=0xfe,
+                                    bInterfaceSubClass=3))
 
     return find_devices(vendor, product, serial_number, is_usbtmc, **kwargs)
 

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -5,7 +5,9 @@
 
     Implements Session to control USBTMC instruments
 
-    Loosely based on PyUSBTMC:python module to handle USB-TMC(Test and Measurement class)　devices.
+    Loosely based on PyUSBTMC:python module to handle USB-TMC(Test and
+    Measurement class)　devices.
+
     by Noboru Yamamot, Accl. Lab, KEK, JAPAN
 
     This file is an offspring of the Lantz Project.
@@ -14,7 +16,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import enum
 from pyvisa.compat import struct
@@ -23,7 +26,8 @@ from collections import namedtuple
 
 import usb
 
-from .usbutil import find_devices, find_interfaces, find_endpoint, usb_find_desc
+from .usbutil import (find_devices, find_interfaces, find_endpoint,
+                      usb_find_desc)
 
 import sys
 
@@ -73,23 +77,29 @@ def find_tmc_devices(vendor=None, product=None, serial_number=None,
 
 
 class BulkOutMessage(object):
-    """The Host uses the Bulk-OUT endpoint to send USBTMC command messages to the device.
+    """The Host uses the Bulk-OUT endpoint to send USBTMC command messages to
+    the device.
+
     """
 
     @staticmethod
     def build_array(btag, eom, chunk):
         size = len(chunk)
-        return struct.pack('BBBx', MsgID.dev_dep_msg_out, btag, ~btag & 0xFF) + \
-               struct.pack("<LBxxx", size, eom) + \
-               chunk + \
-               b'\0' * ((4 - size) % 4)
+        return (struct.pack('BBBx', MsgID.dev_dep_msg_out, btag,
+                            ~btag & 0xFF) +
+                struct.pack("<LBxxx", size, eom) +
+                chunk +
+                b'\0' * ((4 - size) % 4))
 
 
 class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
-                                                'transfer_size transfer_attributes data')):
-    """The Host uses the Bulk-IN endpoint to read USBTMC response messages from the device.
-    The Host must first send a USBTMC command message that expects a response before
-    attempting to read a USBTMC response message.
+                               'transfer_size transfer_attributes data')):
+    """The Host uses the Bulk-IN endpoint to read USBTMC response messages from
+    the device.
+
+    The Host must first send a USBTMC command message that expects a response
+    before attempting to read a USBTMC response message.
+
     """
 
     @classmethod
@@ -97,10 +107,12 @@ class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
         msgid, btag, btaginverse = struct.unpack_from('BBBx', data)
         assert msgid == MsgID.dev_dep_msg_in
 
-        transfer_size, transfer_attributes = struct.unpack_from('<LBxxx', data, 4)
+        transfer_size, transfer_attributes = struct.unpack_from('<LBxxx', data,
+                                                                4)
 
         data = data[12:]
-        return cls(msgid, btag, btaginverse, transfer_size, transfer_attributes, data)
+        return cls(msgid, btag, btaginverse, transfer_size,
+                   transfer_attributes, data)
 
     @staticmethod
     def build_array(btag, transfer_size, term_char=None):
@@ -118,8 +130,10 @@ class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
         else:
             transfer_attributes = 2
 
-        return struct.pack('BBBx', MsgID.request_dev_dep_msg_in, btag, ~btag & 0xFF) + \
-               struct.pack("<LBBxx", transfer_size, transfer_attributes, term_char)
+        return (struct.pack('BBBx', MsgID.request_dev_dep_msg_in, btag,
+                            ~btag & 0xFF) +
+                struct.pack("<LBBxx", transfer_size, transfer_attributes,
+                            term_char))
 
 
 class USBRaw(object):
@@ -129,10 +143,12 @@ class USBRaw(object):
 
     #: Configuration number to be used. If None, the default will be used.
     CONFIGURATION = None
+
     #: Interface index it be used
     INTERFACE = (0, 0)
-    #: Receive and Send endpoints to be used. If None the first IN (or OUT) BULK
-    #: endpoint will be used.
+
+    #: Receive and Send endpoints to be used. If None the first IN (or OUT)
+    #: BULK endpoint will be used.
     ENDPOINTS = (None, None)
 
     timeout = 2000
@@ -146,16 +162,17 @@ class USBRaw(object):
         self.timeout = timeout
 
         device_filters = device_filters or {}
-        devices = list(self.find_devices(vendor, product, serial_number, None, **device_filters))
+        devices = list(self.find_devices(vendor, product, serial_number, None,
+                                         **device_filters))
 
         if not devices:
             raise ValueError('No device found.')
         elif len(devices) > 1:
             desc = '\n'.join(str(dev) for dev in devices)
-            raise ValueError('{} devices found:\n{}\n'
-                             'Please narrow the search criteria'.format(len(devices), desc))
+            raise ValueError('{} devices found:\n{}\nPlease narrow the search'
+                             ' criteria'.format(len(devices), desc))
 
-        self.usb_dev, other = devices[0], devices[1:]
+        self.usb_dev = devices[0]
 
         try:
             if self.usb_dev.is_kernel_driver_active(0):
@@ -175,7 +192,8 @@ class USBRaw(object):
 
         self.usb_intf = self._find_interface(self.usb_dev, self.INTERFACE)
 
-        self.usb_recv_ep, self.usb_send_ep = self._find_endpoints(self.usb_intf, self.ENDPOINTS)
+        self.usb_recv_ep, self.usb_send_ep =\
+            self._find_endpoints(self.usb_intf, self.ENDPOINTS)
 
     def _find_interface(self, dev, setting):
         return self.usb_dev.get_active_configuration()[self.INTERFACE]
@@ -183,12 +201,14 @@ class USBRaw(object):
     def _find_endpoints(self, interface, setting):
         recv, send = setting
         if recv is None:
-            recv = find_endpoint(interface, usb.ENDPOINT_IN, usb.ENDPOINT_TYPE_BULK)
+            recv = find_endpoint(interface, usb.ENDPOINT_IN,
+                                 usb.ENDPOINT_TYPE_BULK)
         else:
             recv = usb_find_desc(interface, bEndpointAddress=recv)
 
         if send is None:
-            send = find_endpoint(interface, usb.ENDPOINT_OUT, usb.ENDPOINT_TYPE_BULK)
+            send = find_endpoint(interface, usb.ENDPOINT_OUT,
+                                 usb.ENDPOINT_TYPE_BULK)
         else:
             send = usb_find_desc(interface, bEndpointAddress=send)
 
@@ -231,9 +251,11 @@ class USBTMC(USBRaw):
 
     find_devices = staticmethod(find_tmc_devices)
 
-    def __init__(self, vendor=None, product=None, serial_number=None, **kwargs):
+    def __init__(self, vendor=None, product=None, serial_number=None,
+                 **kwargs):
         super(USBTMC, self).__init__(vendor, product, serial_number, **kwargs)
-        self.usb_intr_in = find_endpoint(self.usb_intf, usb.ENDPOINT_IN, usb.ENDPOINT_TYPE_INTERRUPT)
+        self.usb_intr_in = find_endpoint(self.usb_intf, usb.ENDPOINT_IN,
+                                         usb.ENDPOINT_TYPE_INTERRUPT)
 
         self.usb_dev.reset()
         self.usb_dev.set_configuration()
@@ -245,21 +267,23 @@ class USBTMC(USBRaw):
         self._btag = 0
 
         if not (self.usb_recv_ep and self.usb_send_ep):
-            raise ValueError("TMC device must have both Bulk-In and Bulk-out endpoints.")
+            msg = "TMC device must have both Bulk-In and Bulk-out endpoints."
+            raise ValueError(msg)
 
     def _get_capabilities(self):
-        cap = self.usb_dev.ctrl_transfer(
-                   usb.util.build_request_type(usb.util.CTRL_IN,
-                                               usb.util.CTRL_TYPE_CLASS,
-                                               usb.util.CTRL_RECIPIENT_INTERFACE),
-                   Request.get_capabilities,
-                   0x0000,
-                   self.usb_intf.index,
-                   0x0018,
-                   timeout=self.timeout)
+        self.usb_dev.ctrl_transfer(
+            usb.util.build_request_type(usb.util.CTRL_IN,
+                                        usb.util.CTRL_TYPE_CLASS,
+                                        usb.util.CTRL_RECIPIENT_INTERFACE),
+            Request.get_capabilities,
+            0x0000,
+            self.usb_intf.index,
+            0x0018,
+            timeout=self.timeout)
 
     def _find_interface(self, dev, setting):
-        interfaces = find_interfaces(dev, bInterfaceClass=0xFE, bInterfaceSubClass=3)
+        interfaces = find_interfaces(dev, bInterfaceClass=0xFE,
+                                     bInterfaceSubClass=3)
         if not interfaces:
             raise ValueError('USB TMC interface not found.')
         elif len(interfaces) > 1:
@@ -284,12 +308,12 @@ class USBTMC(USBRaw):
 
             self._btag = (self._btag % 255) + 1
 
-            data = BulkOutMessage.build_array(self._btag, end > size, data[begin:end])
+            data = BulkOutMessage.build_array(self._btag, end > size,
+                                              data[begin:end])
 
             bytes_sent += raw_write(data)
 
         return bytes_sent
-
 
     def read(self, size):
 
@@ -300,7 +324,7 @@ class USBTMC(USBRaw):
         raw_read = super(USBTMC, self).read
         raw_write = super(USBTMC, self).write
 
-        received = b''
+        received = bytearray()
 
         while not eom:
             self._btag = (self._btag % 255) + 1
@@ -313,8 +337,8 @@ class USBTMC(USBRaw):
 
             response = BulkInMessage.from_bytes(resp)
 
-            received += response.data
+            received.extend(response.data)
 
             eom = response.transfer_attributes & 1
 
-        return received
+        return bytes(received)

--- a/pyvisa-py/protocols/usbutil.py
+++ b/pyvisa-py/protocols/usbutil.py
@@ -120,10 +120,6 @@ AllCodes = {
 }
 
 
-class LantzUSBTimeoutError(usb.core.USBError):
-    pass
-
-
 def ep_attributes(ep):
     c = ep.bmAttributes
     attrs = []
@@ -136,7 +132,7 @@ def ep_attributes(ep):
         attrs.append('Bulk')
     elif tp == usb.ENDPOINT_TYPE_INTERRUPT:
         attrs.append('Interrupt')
-        
+
     sync = (c & 12) >> 2
     if sync == 0:
         attrs.append('No sync')
@@ -159,7 +155,8 @@ def ep_attributes(ep):
     return ', '.join(attrs)
 
 
-def find_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_devices(vendor=None, product=None, serial_number=None,
+                 custom_match=None, **kwargs):
     """Find connected USB devices matching certain keywords.
 
     Wildcards can be used for vendor, product and serial_number.

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -13,7 +13,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import enum
 
@@ -68,6 +69,7 @@ class ErrorCodes(enum.IntEnum):
     io_error = 17
     abort = 23
     channel_already_established = 29
+
 
 # Flags
 OP_FLAG_WAIT_BLOCK = 1
@@ -142,7 +144,8 @@ class Vxi11Packer(rpc.Packer):
         self.pack_uint(lock_timeout)
 
     def pack_device_docmd_parms(self, params):
-        link, flags, io_timeout, lock_timeout, cmd, network_order, datasize, data_in = params
+        (link, flags, io_timeout, lock_timeout,
+         cmd, network_order, datasize, data_in) = params
         self.pack_int(link)
         self.pack_int(flags)
         self.pack_uint(io_timeout)
@@ -194,7 +197,8 @@ class CoreClient(rpc.TCPClient):
     def __init__(self, host, open_timeout=5000):
         self.packer = Vxi11Packer()
         self.unpacker = Vxi11Unpacker('')
-        super(CoreClient, self).__init__(host, DEVICE_CORE_PROG, DEVICE_CORE_VERS, open_timeout)
+        super(CoreClient, self).__init__(host, DEVICE_CORE_PROG,
+                                         DEVICE_CORE_VERS, open_timeout)
 
     def create_link(self, id, lock_device, lock_timeout, name):
         params = (id, lock_device, lock_timeout, name)
@@ -208,8 +212,10 @@ class CoreClient(rpc.TCPClient):
                               self.packer.pack_device_write_parms,
                               self.unpacker.unpack_device_write_resp)
 
-    def device_read(self, link, request_size, io_timeout, lock_timeout, flags, term_char):
-        params = (link, request_size, io_timeout, lock_timeout, flags, term_char)
+    def device_read(self, link, request_size, io_timeout, lock_timeout, flags,
+                    term_char):
+        params = (link, request_size, io_timeout, lock_timeout, flags,
+                  term_char)
         return self.make_call(DEVICE_READ, params,
                               self.packer.pack_device_read_parms,
                               self.unpacker.unpack_device_read_resp)
@@ -261,8 +267,10 @@ class CoreClient(rpc.TCPClient):
                               self.packer.pack_device_enable_srq_parms,
                               self.unpacker.unpack_device_error)
 
-    def device_docmd(self, link, flags, io_timeout, lock_timeout, cmd, network_order, datasize, data_in):
-        params = (link, flags, io_timeout, lock_timeout, cmd, network_order, datasize, data_in)
+    def device_docmd(self, link, flags, io_timeout, lock_timeout, cmd,
+                     network_order, datasize, data_in):
+        params = (link, flags, io_timeout, lock_timeout, cmd, network_order,
+                  datasize, data_in)
         return self.make_call(DEVICE_DOCMD, params,
                               self.packer.pack_device_docmd_parms,
                               self.unpacker.unpack_device_docmd_resp)
@@ -272,7 +280,8 @@ class CoreClient(rpc.TCPClient):
                               self.packer.pack_device_link,
                               self.unpacker.unpack_device_error)
 
-    def create_intr_chan(self, host_addr, host_port, prog_num, prog_vers, prog_family):
+    def create_intr_chan(self, host_addr, host_port, prog_num, prog_vers,
+                         prog_family):
         params = (host_addr, host_port, prog_num, prog_vers, prog_family)
         return self.make_call(CREATE_INTR_CHAN, params,
                               self.packer.pack_device_docmd_parms,

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -191,7 +191,7 @@ class Vxi11Unpacker(rpc.Unpacker):
 
 class CoreClient(rpc.TCPClient):
 
-    def __init__(self, host, open_timeout = 5000):
+    def __init__(self, host, open_timeout=5000):
         self.packer = Vxi11Packer()
         self.unpacker = Vxi11Unpacker('')
         super(CoreClient, self).__init__(host, DEVICE_CORE_PROG, DEVICE_CORE_VERS, open_timeout)

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -191,10 +191,10 @@ class Vxi11Unpacker(rpc.Unpacker):
 
 class CoreClient(rpc.TCPClient):
 
-    def __init__(self, host):
+    def __init__(self, host, open_timeout = 5000):
         self.packer = Vxi11Packer()
         self.unpacker = Vxi11Unpacker('')
-        super(CoreClient, self).__init__(host, DEVICE_CORE_PROG, DEVICE_CORE_VERS)
+        super(CoreClient, self).__init__(host, DEVICE_CORE_PROG, DEVICE_CORE_VERS, open_timeout)
 
     def create_link(self, id, lock_device, lock_timeout, name):
         params = (id, lock_device, lock_timeout, name)

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -242,6 +242,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         `    self.attrs[constants.VI_ATTR_<NAME>] = (self._get_attribute,
                                                      self._set_attribute)`
         """
+        pass
 
     def get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.
@@ -412,7 +413,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                 return bytes(out), StatusCode.error_timeout
 
     def _get_timeout(self, attribute):
-        """  Returns timeout calculated value from python way to VI_ way
+        """ Returns timeout calculated value from python way to VI_ way
 
         """
         if self.timeout is None:
@@ -424,7 +425,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         return ret_value, StatusCode.success
 
     def _set_timeout(self, attribute, value):
-        """  Sets timeout calculated value from python way to VI_ way
+        """ Sets timeout calculated value from python way to VI_ way
+
         """
         if value == constants.VI_TMO_INFINITE:
             self.timeout = None

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -10,7 +10,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import abc
 import time
@@ -21,6 +22,7 @@ from . import common
 
 
 StatusCode = constants.StatusCode
+
 
 class UnknownAttribute(Exception):
 
@@ -197,14 +199,14 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         It is also possible to change handling of already registerd common attributes. List of attributes is available in pyvisa package:
         * name is in constants module as: VI_ATTR_<NAME>
         * validity of attribute for resource is defined module attributes, AttrVI_ATTR_<NAME>.resources
-       
+
         For static (read only) values, simple readonly and also readwrite attributes simplified construction can be used:
         `    self.attrs[constants.VI_ATTR_<NAME>] = 100`
         or
         `    self.attrs[constants.VI_ATTR_<NAME>] = <self.variable_name>`
-        
+
         For more complex handling of attributes, it is possible to register getter and/or setter. When Null is used, NotSupported error is returned.
-        Getter has same signature as see Session._get_attribute and setter has same signature as see Session._set_attribute. (It is possible to register also 
+        Getter has same signature as see Session._get_attribute and setter has same signature as see Session._set_attribute. (It is possible to register also
         see Session._get_attribute and see Session._set_attribute as getter/setter). Getter and Setter are registered as tupple.
         For readwrite attribute:
         `    self.attrs[constants.VI_ATTR_<NAME>] = (<getter_name>, <setter_name>)`
@@ -329,17 +331,19 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :rtype: bytes, constants.StatusCode
         """
 
-        # NOTE: Some interfaces return not only a single byte but a complete block for each read
-        # therefore we must handle the case that the termination character is in the middle of the  block
-        # or that the maximum number of bytes is exceeded
+        # NOTE: Some interfaces return not only a single byte but a complete
+        # block for each read therefore we must handle the case that the
+        # termination character is in the middle of the  block or that the
+        # maximum number of bytes is exceeded
 
         # Make sure termination_char is a string
         try:
-             termination_char = chr(termination_char)
+            termination_char = chr(termination_char)
         except TypeError:
             pass
 
-        finish_time = None if self.timeout is None else (time.time() + self.timeout)
+        finish_time = (None if self.timeout is None else
+                       (time.time() + self.timeout))
         out = b''
         while True:
             try:
@@ -357,18 +361,21 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                 else:
                     if termination_char_en and termination_char in current:
                         # RULE 6.1.2
-                        # Return everything upto and including the termination character
-                        return out[:out.index(termination_char)+1], StatusCode.success_termination_character_read
+                        # Return everything upto and including the termination
+                        # character
+                        return (out[:out.index(termination_char)+1],
+                                StatusCode.success_termination_character_read)
                     elif len(out) >= count:
                         # RULE 6.1.3
                         # Return at most the number of bytes requested
                         return out[:count], StatusCode.success_max_count_read
 
-            if finish_time and time.time() > finish_timeout:
+            if finish_time and time.time() > finish_time:
                 return out, StatusCode.error_timeout
 
     def _get_timeout(self, attribute):
         """  Returns timeout calculated value from python way to VI_ way
+
         """
         if self.timeout is None:
             ret_value = constants.VI_TMO_INFINITE

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -49,7 +49,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
 
     Just makes sure that common methods are defined and information is stored.
 
-    :param resource_manager_session: The session handle of the parent Resource Manager
+    :param resource_manager_session: The session handle of the parent Resource
+        Manager
     :param resource_name: The resource name.
     :param parsed: the parsed resource name (optional).
                    If not provided, the resource_name will be parsed.
@@ -62,7 +63,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         Use to implement custom logic for attributes.
 
         :param attribute: Resource attribute for which the state query is made
-        :return: The state of the queried attribute for a specified resource, return value of the library call.
+        :return: The state of the queried attribute for a specified resource,
+            return value of the library call.
         :rtype: (unicode | str | list | int, VISAStatus)
         """
 
@@ -83,7 +85,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         """Close the session. Use it to do final clean ups.
         """
 
-    #: Maps (Interface Type, Resource Class) to Python class encapsulating that resource.
+    #: Maps (Interface Type, Resource Class) to Python class encapsulating that
+    #: resource.
     #: dict[(Interface Type, Resource Class) , Session]
     _session_classes = dict()
 
@@ -126,7 +129,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         try:
             return cls._session_classes[(interface_type, resource_class)]
         except KeyError:
-            raise ValueError('No class registered for %s, %s' % (interface_type, resource_class))
+            raise ValueError('No class registered for %s, %s' %
+                             (interface_type, resource_class))
 
     @classmethod
     def register(cls, interface_type, resource_class):
@@ -137,17 +141,22 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         """
         def _internal(python_class):
             if (interface_type, resource_class) in cls._session_classes:
-                logger.warning('%s is already registered in the ResourceManager. '
-                               'Overwriting with %s' % ((interface_type, resource_class), python_class))
+                logger.warning('%s is already registered in the '
+                               'ResourceManager. Overwriting with %s',
+                               ((interface_type, resource_class), python_class)
+                               )
 
             python_class.session_type = (interface_type, resource_class)
-            cls._session_classes[(interface_type, resource_class)] = python_class
+            cls._session_classes[(interface_type,
+                                  resource_class)] = python_class
             return python_class
         return _internal
 
     @classmethod
     def register_unavailable(cls, interface_type, resource_class, msg):
-        """Register an unavailable session class for a given interface type and resource class.
+        """Register an unavailable session class for a given interface type and
+        resource class.
+
         raising a ValueError if called.
 
         :type interface_type: constants.InterfaceType
@@ -161,11 +170,13 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
 
         if (interface_type, resource_class) in cls._session_classes:
             logger.warning('%s is already registered in the ResourceManager. '
-                           'Overwriting with unavailable %s' % ((interface_type, resource_class), msg))
+                           'Overwriting with unavailable %s',
+                           ((interface_type, resource_class), msg))
 
         cls._session_classes[(interface_type, resource_class)] = _internal
 
-    def __init__(self, resource_manager_session, resource_name, parsed=None, open_timeout=None):
+    def __init__(self, resource_manager_session, resource_name, parsed=None,
+                 open_timeout=None):
         if isinstance(resource_name, common.MockInterface):
             parsed = rname.parse_resource_name(resource_name.resource_name)
             parsed['mock'] = resource_name
@@ -176,53 +187,71 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         self.parsed = parsed
         self.open_timeout = open_timeout
         #: get default timeout from constants
-        self.timeout = attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default / 1000.0
+        self.timeout =\
+            (attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default /
+             1000.0)
 
-        #: Used as a place holder for the object doing the lowlevel communication.
+        #: Used as a place holder for the object doing the lowlevel
+        #: communication.
         self.interface = None
 
         #: Used for attributes not handled by the underlying interface.
-        #: Values are get or set automatically by get_attribute and set_attribute
+        #: Values are get or set automatically by get_attribute and
+        #: set_attribute
         #: Add your own by overriding after_parsing.
         self.attrs = {constants.VI_ATTR_RM_SESSION: resource_manager_session,
                       constants.VI_ATTR_RSRC_NAME: str(parsed),
                       constants.VI_ATTR_RSRC_CLASS: parsed.resource_class,
                       constants.VI_ATTR_INTF_TYPE: parsed.interface_type,
-                      constants.VI_ATTR_TMO_VALUE: (self._get_timeout, self._set_timeout)}
+                      constants.VI_ATTR_TMO_VALUE: (self._get_timeout,
+                                                    self._set_timeout)}
         self.after_parsing()
 
     def after_parsing(self):
         """Override this method to provide custom initialization code, to be
         called after the resourcename is properly parsed
 
-        ResourceSession can register resource specific attributes handling of them into self.attrs.
-        It is also possible to change handling of already registerd common attributes. List of attributes is available in pyvisa package:
+        ResourceSession can register resource specific attributes handling of
+        them into self.attrs.
+        It is also possible to change handling of already registerd common
+        attributes. List of attributes is available in pyvisa package:
         * name is in constants module as: VI_ATTR_<NAME>
-        * validity of attribute for resource is defined module attributes, AttrVI_ATTR_<NAME>.resources
+        * validity of attribute for resource is defined module attributes,
+        AttrVI_ATTR_<NAME>.resources
 
-        For static (read only) values, simple readonly and also readwrite attributes simplified construction can be used:
+        For static (read only) values, simple readonly and also readwrite
+        attributes simplified construction can be used:
         `    self.attrs[constants.VI_ATTR_<NAME>] = 100`
         or
         `    self.attrs[constants.VI_ATTR_<NAME>] = <self.variable_name>`
 
-        For more complex handling of attributes, it is possible to register getter and/or setter. When Null is used, NotSupported error is returned.
-        Getter has same signature as see Session._get_attribute and setter has same signature as see Session._set_attribute. (It is possible to register also
-        see Session._get_attribute and see Session._set_attribute as getter/setter). Getter and Setter are registered as tupple.
+        For more complex handling of attributes, it is possible to register
+        getter and/or setter. When Null is used, NotSupported error is
+        returned.
+        Getter has same signature as see Session._get_attribute and setter has
+        same signature as see Session._set_attribute. (It is possible to
+        register also see Session._get_attribute and see Session._set_attribute
+        as getter/setter). Getter and Setter are registered as tupple.
         For readwrite attribute:
-        `    self.attrs[constants.VI_ATTR_<NAME>] = (<getter_name>, <setter_name>)`
+        `    self.attrs[constants.VI_ATTR_<NAME>] = (<getter_name>,
+                                                     <setter_name>)`
         For readonly attribute:
         `    self.attrs[constants.VI_ATTR_<NAME>] = (<getter_name>, None)`
-        For reusing of see Session._get_attribute and see Session._set_attribute
-        `    self.attrs[constants.VI_ATTR_<NAME>] = (self._get_attribute, self._set_attribute)`
+        For reusing of see Session._get_attribute and see
+        Session._set_attribute
+        `    self.attrs[constants.VI_ATTR_<NAME>] = (self._get_attribute,
+                                                     self._set_attribute)`
         """
 
     def get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.
 
-        Does a few checks before and calls before dispatching to `_get_attribute`.
+        Does a few checks before and calls before dispatching to
+        `_get_attribute`.
 
         :param attribute: Resource attribute for which the state query is made
-        :return: The state of the queried attribute for a specified resource, return value of the library call.
+        :return: The state of the queried attribute for a specified resource,
+            return value of the library call.
         :rtype: (unicode | str | list | int, VISAStatus)
         """
 
@@ -240,16 +269,18 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         if not attr.read:
             raise Exception('Do not now how to handle write only attributes.')
 
-        # First try to answer those attributes that are registered in self.attrs, see Session.after_parsing
+        # First try to answer those attributes that are registered in
+        # self.attrs, see Session.after_parsing
         if attribute in self.attrs:
             value = self.attrs[attribute]
             status = StatusCode.success
             if isinstance(value, tuple):
                 getter = value[0]
-                value, status = getter(attribute) if getter else (0, StatusCode.error_nonsupported_attribute)
+                value, status = (getter(attribute) if getter else
+                                 (0, StatusCode.error_nonsupported_attribute))
             return value, status
 
-        # Dispatch to `_get_attribute`, which must be implemented by subclasses.
+        # Dispatch to `_get_attribute`, which must be implemented by subclasses
 
         try:
             return self._get_attribute(attribute)
@@ -258,9 +289,11 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
             return 0, StatusCode.error_nonsupported_attribute
 
     def set_attribute(self, attribute, attribute_state):
-        """Set the attribute_state value for a given VISA attribute for this session.
+        """Set the attribute_state value for a given VISA attribute for this
+        session.
 
-        Does a few checks before and calls before dispatching to `_gst_attribute`.
+        Does a few checks before and calls before dispatching to
+        `_gst_attribute`.
 
         :param attribute: Resource attribute for which the state query is made.
         :param attribute_state: value.
@@ -282,18 +315,20 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         if not attr.write:
             return StatusCode.error_attribute_read_only
 
-        # First try to answer those attributes that are registered in self.attrs, see Session.after_parsing
+        # First try to answer those attributes that are registered in
+        # self.attrs, see Session.after_parsing
         if attribute in self.attrs:
             value = self.attrs[attribute]
             status = StatusCode.success
             if isinstance(value, tuple):
                 setter = value[1]
-                status = setter(attribute, attribute_state) if setter else StatusCode.error_nonsupported_attribute
+                status = (setter(attribute, attribute_state) if setter else
+                          StatusCode.error_nonsupported_attribute)
             else:
                 self.attrs[attribute] = attribute_state
             return status
 
-        # Dispatch to `_set_attribute`, which must be implemented by subclasses.
+        # Dispatch to `_set_attribute`, which must be implemented by subclasses
 
         try:
             return self._set_attribute(attribute, attribute_state)
@@ -317,7 +352,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :type reader: () -> bytes
         :param count: Number of bytes to be read.
         :type count: int
-        :param end_indicator_checker: Function to check if the message is complete.
+        :param end_indicator_checker: Function to check if the message is
+            complete.
         :type end_indicator_checker: (bytes) -> boolean
         :param suppress_end_en: suppress end.
         :type suppress_end_en: bool
@@ -325,7 +361,8 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :type suppress_end_en: int or str
         :param termination_char_en: termination char enabled.
         :type termination_char_en: boolean
-        :param: timeout_exception: Exception to capture time out for the given interface.
+        :param: timeout_exception: Exception to capture time out for the given
+            interface.
         :type: Exception
         :return: data read, return value of the library call.
         :rtype: bytes, constants.StatusCode
@@ -395,4 +432,4 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
             self.timeout = 0
         else:
             self.timeout = value / 1000.0
-        return StatusCode.success;
+        return StatusCode.success

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -40,7 +40,8 @@ class TCPIPInstrSession(Session):
     def after_parsing(self):
         # TODO: board_number not handled
         # TODO: lan_device_name not handled
-        self.interface = vxi11.CoreClient(self.parsed.host_address, self.open_timeout)
+        self.interface = vxi11.CoreClient(self.parsed.host_address,
+                                          self.open_timeout)
 
         self.max_recv_size = 1024
         self.lock_timeout = 10000
@@ -57,7 +58,8 @@ class TCPIPInstrSession(Session):
 
         for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
-            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+            self.attrs[attribute] =\
+                attributes.AttributesByID[attribute].default
 
     def close(self):
         try:
@@ -127,7 +129,8 @@ class TCPIPInstrSession(Session):
 
         :param data: data to be written.
         :type data: str
-        :return: Number of bytes actually transferred, return value of the library call.
+        :return: Number of bytes actually transferred, return value of the
+            library call.
         :rtype: int, VISAStatus
         """
 
@@ -174,7 +177,8 @@ class TCPIPInstrSession(Session):
         Use to implement custom logic for attributes.
 
         :param attribute: Resource attribute for which the state query is made
-        :return: The state of the queried attribute for a specified resource, return value of the library call.
+        :return: The state of the queried attribute for a specified resource,
+            return value of the library call.
         :rtype: (unicode | str | list | int, VISAStatus)
         """
 
@@ -206,8 +210,10 @@ class TCPIPInstrSession(Session):
 
         Corresponds to viSetAttribute function of the VISA library.
 
-        :param attribute: Attribute for which the state is to be modified. (Attributes.*)
-        :param attribute_state: The state of the attribute to be set for the specified object.
+        :param attribute: Attribute for which the state is to be modified.
+            (Attributes.*)
+        :param attribute_state: The state of the attribute to be set for the
+            specified object.
         :return: return value of the library call.
         :rtype: VISAStatus
         """
@@ -219,7 +225,8 @@ class TCPIPInstrSession(Session):
 
         Corresponds to viAssertTrigger function of the VISA library.
 
-        :param protocol: Trigger protocol to use during assertion. (Constants.PROT*)
+        :param protocol: Trigger protocol to use during assertion.
+            (Constants.PROT*)
         :return: return value of the library call.
         :rtype: VISAStatus
         """
@@ -275,11 +282,15 @@ class TCPIPInstrSession(Session):
 
         Corresponds to viLock function of the VISA library.
 
-        :param lock_type: Specifies the type of lock requested, either Constants.EXCLUSIVE_LOCK or Constants.SHARED_LOCK.
-        :param timeout: Absolute time period (in milliseconds) that a resource waits to get unlocked by the
-                        locking session before returning an error.
-        :param requested_key: This parameter is not used and should be set to VI_NULL when lockType is VI_EXCLUSIVE_LOCK.
-        :return: access_key that can then be passed to other sessions to share the lock, return value of the library call.
+        :param lock_type: Specifies the type of lock requested, either
+            Constants.EXCLUSIVE_LOCK or Constants.SHARED_LOCK.
+        :param timeout: Absolute time period (in milliseconds) that a resource
+            waits to get unlocked by the locking session before returning an
+            error.
+        :param requested_key: This parameter is not used and should be set to
+            VI_NULL when lockType is VI_EXCLUSIVE_LOCK.
+        :return: access_key that can then be passed to other sessions to share
+            the lock, return value of the library call.
         :rtype: str, VISAStatus
         """
 
@@ -309,15 +320,16 @@ class TCPIPInstrSession(Session):
 
 @Session.register(constants.InterfaceType.tcpip, 'SOCKET')
 class TCPIPSocketSession(Session):
-    """A TCPIP Session that uses the network standard library to do the low level communication.
+    """A TCPIP Session that uses the network standard library to do the low
+    level communication.
+
     """
     # Details about implementation:
-    # On Windows, select is not interrupted by KeyboardInterrupt, to avoid blocking
-    # for very long time, we use a decreasing timeout in select
-    # minimum select timeout to avoid too short select interval is also calculated
-    # and select timeout is not lower that that minimum timeout
+    # On Windows, select is not interrupted by KeyboardInterrupt, to avoid
+    # blocking for very long time, we use a decreasing timeout in select
+    # minimum select timeout to avoid too short select interval is also
+    # calculated and select timeout is not lower that that minimum timeout
     # Tis is valid for connect and read operations
-
 
     @staticmethod
     def list_resources():
@@ -333,28 +345,33 @@ class TCPIPSocketSession(Session):
             raise Exception("could not connect: {0}".format(str(ret_status)))
 
         self.max_recv_size = 4096
-        # This buffer is used to store the bytes that appeared after termination char
+        # This buffer is used to store the bytes that appeared after
+        # termination char
         self._pending_buffer = bytearray()
 
         self.attrs[constants.VI_ATTR_TCPIP_ADDR] = self.parsed.host_address
         self.attrs[constants.VI_ATTR_TCPIP_PORT] = self.parsed.port
         self.attrs[constants.VI_ATTR_INTF_NUM] = self.parsed.board
-        self.attrs[constants.VI_ATTR_TCPIP_NODELAY] = (self._get_tcpip_nodelay, self._set_attribute)
+        self.attrs[constants.VI_ATTR_TCPIP_NODELAY] = (self._get_tcpip_nodelay,
+                                                       self._set_attribute)
         self.attrs[constants.VI_ATTR_TCPIP_HOSTNAME] = ''
-        self.attrs[constants.VI_ATTR_TCPIP_KEEPALIVE] = (self._get_tcpip_keepalive, self._set_tcpip_keepalive)
+        self.attrs[constants.VI_ATTR_TCPIP_KEEPALIVE] = \
+            (self._get_tcpip_keepalive, self._set_tcpip_keepalive)
         # to use default as ni visa driver (NI-VISA 15.0)
         self.attrs[constants.VI_ATTR_SUPPRESS_END_EN] = True
 
         for name in ('TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
-            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+            self.attrs[attribute] =\
+                attributes.AttributesByID[attribute].default
 
     def _connect(self):
         timeout = self.open_timeout / 1000.0 if self.open_timeout else 10.0
         try:
             self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.interface.setblocking(0)
-            self.interface.connect_ex((self.parsed.host_address, int(self.parsed.port)))
+            self.interface.connect_ex((self.parsed.host_address,
+                                       int(self.parsed.port)))
         except Exception as e:
             raise Exception("could not connect: {0}".format(str(e)))
         finally:
@@ -362,14 +379,15 @@ class TCPIPSocketSession(Session):
 
         # minimum is in interval 100 - 500ms based on timeout
         min_select_timeout = max(min(timeout/10.0, 0.5), 0.1)
-        # initial 'select_timout' is half of timeout or max 2 secs (max blocking time).
-        # min is from 'min_select_timeout'
+        # initial 'select_timout' is half of timeout or max 2 secs
+        # (max blocking time). min is from 'min_select_timeout'
         select_timout = max(min(timeout/2.0, 2.0), min_select_timeout)
         # time, when loop shall finish
         finish_time = time.time() + timeout
         while True:
             # use select to wait for socket ready, max `select_timout` seconds
-            r, w, x = select.select([self.interface], [self.interface], [], select_timout)
+            r, w, x = select.select([self.interface], [self.interface], [],
+                                    select_timout)
             if self.interface in r or self.interface in w:
                 return StatusCode.success
 
@@ -377,7 +395,8 @@ class TCPIPSocketSession(Session):
                 # reached timeout
                 return StatusCode.error_timeout
 
-            # `select_timout` decreased to 50% of previous or min_select_timeout
+            # `select_timout` decreased to 50% of previous or
+            # min_select_timeout
             select_timout = max(select_timout / 2.0, min_select_timeout)
 
     def close(self):
@@ -401,20 +420,27 @@ class TCPIPSocketSession(Session):
         term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
         term_byte = common.int_to_byte(term_char) if term_char else b''
         term_char_en, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
-        suppress_end_en, _ = self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
+        suppress_end_en, _ =\
+            self.get_attribute(constants.VI_ATTR_SUPPRESS_END_EN)
 
         read_fun = self.interface.recv
 
-        # minimum is in interval 1 - 100ms based on timeout, 1sec if no timeut defined
-        min_select_timeout = 1 if self.timeout is None else max(min(self.timeout / 100.0, 0.1), 0.001)
-        # initial 'select_timout' is half of timeout or max 2 secs (max blocking time).
-        # min is from 'min_select_timeout'
-        select_timout = 2.0 if self.timeout is None else max(min(self.timeout / 2.0, 2.0), min_select_timeout)
-        # time, when loop shall finish, None means never ending story if no data arrives
-        finish_time = None if self.timeout is None else (time.time() + self.timeout)
+        # minimum is in interval 1 - 100ms based on timeout, 1sec if no timeout
+        # defined
+        min_select_timeout = (1 if self.timeout is None else
+                              max(min(self.timeout / 100.0, 0.1), 0.001))
+        # initial 'select_timout' is half of timeout or max 2 secs
+        # (max blocking time). min is from 'min_select_timeout'
+        select_timout = (2.0 if self.timeout is None else
+                         max(min(self.timeout / 2.0, 2.0), min_select_timeout))
+        # time, when loop shall finish, None means never ending story if no
+        # data arrives
+        finish_time = (None if self.timeout is None else
+                       (time.time() + self.timeout))
         while True:
 
-            # check, if we have any data received (from pending buffer or further reading)
+            # check, if we have any data received (from pending buffer or
+            # further reading)
             if term_char_en and term_byte in self._pending_buffer:
                 term_byte_index = self._pending_buffer.index(term_byte) + 1
                 if term_byte_index > count:
@@ -442,7 +468,8 @@ class TCPIPSocketSession(Session):
             if not read_data:
                 # can't read chunk or timeout
                 if self._pending_buffer and not suppress_end_en:
-                    # we have some data without termchar but no further data expected
+                    # we have some data without termchar but no further data
+                    # expected
                     out = bytes(self._pending_buffer[:count])
                     self._pending_buffer = self._pending_buffer[count:]
                     return out, StatusCode.succes
@@ -453,7 +480,8 @@ class TCPIPSocketSession(Session):
                     self._pending_buffer = self._pending_buffer[count:]
                     return out, StatusCode.error_timeout
 
-                # `select_timout` decreased to 50% of previous or min_select_timeout
+                # `select_timout` decreased to 50% of previous or
+                # min_select_timeout
                 select_timout = max(select_timout / 2.0, min_select_timeout)
 
     def write(self, data):
@@ -463,7 +491,8 @@ class TCPIPSocketSession(Session):
 
         :param data: data to be written.
         :type data: str
-        :return: Number of bytes actually transferred, return value of the library call.
+        :return: Number of bytes actually transferred, return value of the
+            library call.
         :rtype: int, VISAStatus
         """
 
@@ -494,26 +523,32 @@ class TCPIPSocketSession(Session):
 
     def _get_tcpip_nodelay(self, attribute):
         if self.interface:
-           value = self.interface.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
-           return constants.VI_TRUE if value == 1 else constants.VI_FALSE, StatusCode.succes
+            value = self.interface.getsockopt(socket.IPPROTO_TCP,
+                                              socket.TCP_NODELAY)
+            return (constants.VI_TRUE if value == 1 else
+                    constants.VI_FALSE, StatusCode.succes)
         return 0, StatusCode.error_nonsupported_attribute
 
     def _set_tcpip_nodelay(self, attribute, attribute_state):
         if self.interface:
-           self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1 if attribute_state else 0)
-           return StatusCode.succes
+            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
+                                      1 if attribute_state else 0)
+            return StatusCode.succes
         return 0, StatusCode.error_nonsupported_attribute
 
     def _get_tcpip_keepalive(self, attribute):
         if self.interface:
-           value = self.interface.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
-           return constants.VI_TRUE if value == 1 else constants.VI_FALSE, StatusCode.succes
+            value = self.interface.getsockopt(socket.SOL_SOCKET,
+                                              socket.SO_KEEPALIVE)
+            return (constants.VI_TRUE if value == 1 else
+                    constants.VI_FALSE, StatusCode.succes)
         return 0, StatusCode.error_nonsupported_attribute
 
     def _set_tcpip_keepalive(self, attribute, attribute_state):
         if self.interface:
-           self.interface.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1 if attribute_state else 0)
-           return StatusCode.succes
+            self.interface.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE,
+                                      1 if attribute_state else 0)
+            return StatusCode.succes
         return 0, StatusCode.error_nonsupported_attribute
 
     def _get_attribute(self, attribute):
@@ -522,7 +557,8 @@ class TCPIPSocketSession(Session):
         Use to implement custom logic for attributes.
 
         :param attribute: Resource attribute for which the state query is made
-        :return: The state of the queried attribute for a specified resource, return value of the library call.
+        :return: The state of the queried attribute for a specified resource,
+            return value of the library call.
         :rtype: (unicode | str | list | int, VISAStatus)
         """
         raise UnknownAttribute(attribute)
@@ -532,8 +568,10 @@ class TCPIPSocketSession(Session):
 
         Corresponds to viSetAttribute function of the VISA library.
 
-        :param attribute: Attribute for which the state is to be modified. (Attributes.*)
-        :param attribute_state: The state of the attribute to be set for the specified object.
+        :param attribute: Attribute for which the state is to be modified.
+            (Attributes.*)
+        :param attribute_state: The state of the attribute to be set for the
+            specified object.
         :return: return value of the library call.
         :rtype: VISAStatus
         """

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -27,8 +27,9 @@ StatusCode = constants.StatusCode
 
 @Session.register(constants.InterfaceType.tcpip, 'INSTR')
 class TCPIPInstrSession(Session):
-    """A TCPIP Session that uses the network standard library to do the low level communication
-    using VXI-11
+    """A TCPIP Session that uses the network standard library to do the low
+    level communication using VXI-11
+
     """
 
     lock_timeout = 1000
@@ -88,7 +89,6 @@ class TCPIPInstrSession(Session):
 
         if self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)[0]:
             term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
-            term_char = str(term_char).encode('utf-8')[0]
             flags = vxi11.OP_FLAG_TERMCHAR_SET
         else:
             term_char = flags = 0
@@ -98,6 +98,8 @@ class TCPIPInstrSession(Session):
 
         read_data = bytearray()
         reason = 0
+        # Stop on end of message or when a termination character has been
+        # encountered.
         end_reason = vxi11.RX_END | vxi11.RX_CHR
         read_fun = self.interface.device_read
         status = StatusCode.success
@@ -448,7 +450,7 @@ class TCPIPSocketSession(Session):
                     out = bytes(self._pending_buffer[:count])
                     self._pending_buffer = self._pending_buffer[count:]
                     return out, StatusCode.succes
-    
+
                 if finish_time and time.time() >= finish_time:
                     # reached timeout
                     out = bytes(self._pending_buffer[:count])

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -32,11 +32,6 @@ class TCPIPInstrSession(Session):
 
     """
 
-    lock_timeout = 1000
-    client_id = None
-    link = None
-    max_recv_size = 1024
-
     @staticmethod
     def list_resources():
         # TODO: is there a way to get this?
@@ -47,6 +42,7 @@ class TCPIPInstrSession(Session):
         # TODO: lan_device_name not handled
         self.interface = vxi11.CoreClient(self.parsed.host_address, self.open_timeout)
 
+        self.max_recv_size = 1024
         self.lock_timeout = 10000
         self.client_id = random.getrandbits(31)
 

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -45,7 +45,7 @@ class TCPIPInstrSession(Session):
     def after_parsing(self):
         # TODO: board_number not handled
         # TODO: lan_device_name not handled
-        self.interface = vxi11.CoreClient(self.parsed.host_address)
+        self.interface = vxi11.CoreClient(self.parsed.host_address, self.open_timeout)
 
         self.lock_timeout = 10000
         self.client_id = random.getrandbits(31)

--- a/pyvisa-py/testsuite/__init__.py
+++ b/pyvisa-py/testsuite/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import os
 
-from pyvisa.compat import unittest
+import unittest
 
 
 def testsuite():
@@ -29,4 +30,3 @@ def run():
     """
     test_runner = unittest.TextTestRunner()
     return test_runner.run(testsuite())
-

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ __doc__ = long_description
 
 requirements = ['pyvisa>=1.8']
 
-if sys.version_info < (2, 7):
-    requirements.append('importlib')
 
 setup(name='PyVISA-py',
       description='Python VISA bindings for GPIB, RS232, and USB instruments',
@@ -57,10 +55,7 @@ setup(name='PyVISA-py',
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
* `rpc` module changes:
  * updated to use timeout and fragmentation size in recv and write operations
  * fragmentation support in write operation
  * connect is timeouted based on timeout
  * 'select' moved to `_sendrecord` and `_recvrecord` functions
* `tcpip` module:
 * open_timeout passed to rpc via vxi11

Related to #88