### PR TITLE
Clean up and fix a nasty bug in tcpip instr session.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,8 +86,9 @@ Now:
 Are all VISA attributes and methods implemented?
 ------------------------------------------------
 
-No. We have implemented those attributes and methods that are most commonly needed.
-We would like to reach feature parity. If there is something that you need, let us know.
+No. We have implemented those attributes and methods that are most commonly
+needed. We would like to reach feature parity. If there is something that you
+need, let us know.
 
 
 Why are you developing this?
@@ -100,9 +101,9 @@ We wanted to provide a compatible alternative.
 Why not using LibreVISA?
 ------------------------
 
-LibreVISA_ is still young. However, you can already use it with the NI backend as it
-has the same API. We think that PyVISA-py is easier to hack and we can quickly
-reach feature parity with NI-VISA for message-based instruments.
+LibreVISA_ is still young. However, you can already use it with the NI backend
+as it has the same API. We think that PyVISA-py is easier to hack and we can
+quickly reach feature parity with NI-VISA for message-based instruments.
 
 
 Why putting PyVISA in the middle?

--- a/pyvisa-py/protocols/usbraw.py
+++ b/pyvisa-py/protocols/usbraw.py
@@ -77,11 +77,11 @@ class USBRawDevice(USBRaw):
 
         raw_read = super(USBRawDevice, self).read
 
-        received = b''
+        received = bytearray()
 
         while not len(received) >= size:
             resp = raw_read(self.RECV_CHUNK)
 
-            received += resp
+            received.extend(resp)
 
-        return received
+        return bytes(received)

--- a/pyvisa-py/protocols/usbraw.py
+++ b/pyvisa-py/protocols/usbraw.py
@@ -18,18 +18,18 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 
 from .usbtmc import USBRaw as USBRaw
 
-import usb
-
-from .usbutil import find_devices, find_interfaces, find_endpoint, usb_find_desc
+from .usbutil import find_devices, find_interfaces
 
 
-def find_raw_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_raw_devices(vendor=None, product=None, serial_number=None,
+                     custom_match=None, **kwargs):
     """Find connected USB RAW devices. See usbutil.find_devices for more info.
     """
     def is_usbraw(dev):
         if custom_match and not custom_match(dev):
             return False
-        return bool(find_interfaces(dev, bInterfaceClass=0xFF, bInterfaceSubClass=0xFF))
+        return bool(find_interfaces(dev, bInterfaceClass=0xFF,
+                                    bInterfaceSubClass=0xFF))
 
     return find_devices(vendor, product, serial_number, is_usbraw, **kwargs)
 
@@ -66,7 +66,6 @@ class USBRawDevice(USBRaw):
 
         return bytes_sent
 
-
     def read(self, size):
         """Read raw bytes from the instrument.
 
@@ -77,7 +76,6 @@ class USBRawDevice(USBRaw):
         """
 
         raw_read = super(USBRawDevice, self).read
-        raw_write = super(USBRawDevice, self).write
 
         received = b''
 

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -58,13 +58,16 @@ class Request(enum.IntEnum):
     indicator_pulse = 64
 
 
-def find_tmc_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_tmc_devices(vendor=None, product=None, serial_number=None,
+                     custom_match=None, **kwargs):
     """Find connected USBTMC devices. See usbutil.find_devices for more info.
+
     """
     def is_usbtmc(dev):
         if custom_match and not custom_match(dev):
             return False
-        return bool(find_interfaces(dev, bInterfaceClass=0xfe, bInterfaceSubClass=3))
+        return bool(find_interfaces(dev, bInterfaceClass=0xfe,
+                                    bInterfaceSubClass=3))
 
     return find_devices(vendor, product, serial_number, is_usbtmc, **kwargs)
 

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -5,7 +5,9 @@
 
     Implements Session to control USBTMC instruments
 
-    Loosely based on PyUSBTMC:python module to handle USB-TMC(Test and Measurement class)　devices.
+    Loosely based on PyUSBTMC:python module to handle USB-TMC(Test and
+    Measurement class)　devices.
+
     by Noboru Yamamot, Accl. Lab, KEK, JAPAN
 
     This file is an offspring of the Lantz Project.
@@ -14,7 +16,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import enum
 from pyvisa.compat import struct
@@ -23,7 +26,8 @@ from collections import namedtuple
 
 import usb
 
-from .usbutil import find_devices, find_interfaces, find_endpoint, usb_find_desc
+from .usbutil import (find_devices, find_interfaces, find_endpoint,
+                      usb_find_desc)
 
 import sys
 
@@ -73,23 +77,29 @@ def find_tmc_devices(vendor=None, product=None, serial_number=None,
 
 
 class BulkOutMessage(object):
-    """The Host uses the Bulk-OUT endpoint to send USBTMC command messages to the device.
+    """The Host uses the Bulk-OUT endpoint to send USBTMC command messages to
+    the device.
+
     """
 
     @staticmethod
     def build_array(btag, eom, chunk):
         size = len(chunk)
-        return struct.pack('BBBx', MsgID.dev_dep_msg_out, btag, ~btag & 0xFF) + \
-               struct.pack("<LBxxx", size, eom) + \
-               chunk + \
-               b'\0' * ((4 - size) % 4)
+        return (struct.pack('BBBx', MsgID.dev_dep_msg_out, btag,
+                            ~btag & 0xFF) +
+                struct.pack("<LBxxx", size, eom) +
+                chunk +
+                b'\0' * ((4 - size) % 4))
 
 
 class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
-                                                'transfer_size transfer_attributes data')):
-    """The Host uses the Bulk-IN endpoint to read USBTMC response messages from the device.
-    The Host must first send a USBTMC command message that expects a response before
-    attempting to read a USBTMC response message.
+                               'transfer_size transfer_attributes data')):
+    """The Host uses the Bulk-IN endpoint to read USBTMC response messages from
+    the device.
+
+    The Host must first send a USBTMC command message that expects a response
+    before attempting to read a USBTMC response message.
+
     """
 
     @classmethod
@@ -97,10 +107,12 @@ class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
         msgid, btag, btaginverse = struct.unpack_from('BBBx', data)
         assert msgid == MsgID.dev_dep_msg_in
 
-        transfer_size, transfer_attributes = struct.unpack_from('<LBxxx', data, 4)
+        transfer_size, transfer_attributes = struct.unpack_from('<LBxxx', data,
+                                                                4)
 
         data = data[12:]
-        return cls(msgid, btag, btaginverse, transfer_size, transfer_attributes, data)
+        return cls(msgid, btag, btaginverse, transfer_size,
+                   transfer_attributes, data)
 
     @staticmethod
     def build_array(btag, transfer_size, term_char=None):
@@ -118,8 +130,10 @@ class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
         else:
             transfer_attributes = 2
 
-        return struct.pack('BBBx', MsgID.request_dev_dep_msg_in, btag, ~btag & 0xFF) + \
-               struct.pack("<LBBxx", transfer_size, transfer_attributes, term_char)
+        return (struct.pack('BBBx', MsgID.request_dev_dep_msg_in, btag,
+                            ~btag & 0xFF) +
+                struct.pack("<LBBxx", transfer_size, transfer_attributes,
+                            term_char))
 
 
 class USBRaw(object):
@@ -129,10 +143,12 @@ class USBRaw(object):
 
     #: Configuration number to be used. If None, the default will be used.
     CONFIGURATION = None
+
     #: Interface index it be used
     INTERFACE = (0, 0)
-    #: Receive and Send endpoints to be used. If None the first IN (or OUT) BULK
-    #: endpoint will be used.
+
+    #: Receive and Send endpoints to be used. If None the first IN (or OUT)
+    #: BULK endpoint will be used.
     ENDPOINTS = (None, None)
 
     timeout = 2000
@@ -146,16 +162,17 @@ class USBRaw(object):
         self.timeout = timeout
 
         device_filters = device_filters or {}
-        devices = list(self.find_devices(vendor, product, serial_number, None, **device_filters))
+        devices = list(self.find_devices(vendor, product, serial_number, None,
+                                         **device_filters))
 
         if not devices:
             raise ValueError('No device found.')
         elif len(devices) > 1:
             desc = '\n'.join(str(dev) for dev in devices)
-            raise ValueError('{} devices found:\n{}\n'
-                             'Please narrow the search criteria'.format(len(devices), desc))
+            raise ValueError('{} devices found:\n{}\nPlease narrow the search'
+                             ' criteria'.format(len(devices), desc))
 
-        self.usb_dev, other = devices[0], devices[1:]
+        self.usb_dev = devices[0]
 
         try:
             if self.usb_dev.is_kernel_driver_active(0):
@@ -175,7 +192,8 @@ class USBRaw(object):
 
         self.usb_intf = self._find_interface(self.usb_dev, self.INTERFACE)
 
-        self.usb_recv_ep, self.usb_send_ep = self._find_endpoints(self.usb_intf, self.ENDPOINTS)
+        self.usb_recv_ep, self.usb_send_ep =\
+            self._find_endpoints(self.usb_intf, self.ENDPOINTS)
 
     def _find_interface(self, dev, setting):
         return self.usb_dev.get_active_configuration()[self.INTERFACE]
@@ -183,12 +201,14 @@ class USBRaw(object):
     def _find_endpoints(self, interface, setting):
         recv, send = setting
         if recv is None:
-            recv = find_endpoint(interface, usb.ENDPOINT_IN, usb.ENDPOINT_TYPE_BULK)
+            recv = find_endpoint(interface, usb.ENDPOINT_IN,
+                                 usb.ENDPOINT_TYPE_BULK)
         else:
             recv = usb_find_desc(interface, bEndpointAddress=recv)
 
         if send is None:
-            send = find_endpoint(interface, usb.ENDPOINT_OUT, usb.ENDPOINT_TYPE_BULK)
+            send = find_endpoint(interface, usb.ENDPOINT_OUT,
+                                 usb.ENDPOINT_TYPE_BULK)
         else:
             send = usb_find_desc(interface, bEndpointAddress=send)
 
@@ -231,9 +251,11 @@ class USBTMC(USBRaw):
 
     find_devices = staticmethod(find_tmc_devices)
 
-    def __init__(self, vendor=None, product=None, serial_number=None, **kwargs):
+    def __init__(self, vendor=None, product=None, serial_number=None,
+                 **kwargs):
         super(USBTMC, self).__init__(vendor, product, serial_number, **kwargs)
-        self.usb_intr_in = find_endpoint(self.usb_intf, usb.ENDPOINT_IN, usb.ENDPOINT_TYPE_INTERRUPT)
+        self.usb_intr_in = find_endpoint(self.usb_intf, usb.ENDPOINT_IN,
+                                         usb.ENDPOINT_TYPE_INTERRUPT)
 
         self.usb_dev.reset()
         self.usb_dev.set_configuration()
@@ -245,21 +267,23 @@ class USBTMC(USBRaw):
         self._btag = 0
 
         if not (self.usb_recv_ep and self.usb_send_ep):
-            raise ValueError("TMC device must have both Bulk-In and Bulk-out endpoints.")
+            msg = "TMC device must have both Bulk-In and Bulk-out endpoints."
+            raise ValueError(msg)
 
     def _get_capabilities(self):
-        cap = self.usb_dev.ctrl_transfer(
-                   usb.util.build_request_type(usb.util.CTRL_IN,
-                                               usb.util.CTRL_TYPE_CLASS,
-                                               usb.util.CTRL_RECIPIENT_INTERFACE),
-                   Request.get_capabilities,
-                   0x0000,
-                   self.usb_intf.index,
-                   0x0018,
-                   timeout=self.timeout)
+        self.usb_dev.ctrl_transfer(
+            usb.util.build_request_type(usb.util.CTRL_IN,
+                                        usb.util.CTRL_TYPE_CLASS,
+                                        usb.util.CTRL_RECIPIENT_INTERFACE),
+            Request.get_capabilities,
+            0x0000,
+            self.usb_intf.index,
+            0x0018,
+            timeout=self.timeout)
 
     def _find_interface(self, dev, setting):
-        interfaces = find_interfaces(dev, bInterfaceClass=0xFE, bInterfaceSubClass=3)
+        interfaces = find_interfaces(dev, bInterfaceClass=0xFE,
+                                     bInterfaceSubClass=3)
         if not interfaces:
             raise ValueError('USB TMC interface not found.')
         elif len(interfaces) > 1:
@@ -284,12 +308,12 @@ class USBTMC(USBRaw):
 
             self._btag = (self._btag % 255) + 1
 
-            data = BulkOutMessage.build_array(self._btag, end > size, data[begin:end])
+            data = BulkOutMessage.build_array(self._btag, end > size,
+                                              data[begin:end])
 
             bytes_sent += raw_write(data)
 
         return bytes_sent
-
 
     def read(self, size):
 
@@ -300,7 +324,7 @@ class USBTMC(USBRaw):
         raw_read = super(USBTMC, self).read
         raw_write = super(USBTMC, self).write
 
-        received = b''
+        received = bytearray()
 
         while not eom:
             self._btag = (self._btag % 255) + 1
@@ -313,8 +337,8 @@ class USBTMC(USBRaw):
 
             response = BulkInMessage.from_bytes(resp)
 
-            received += response.data
+            received.extend(response.data)
 
             eom = response.transfer_attributes & 1
 
-        return received
+        return bytes(received)

--- a/pyvisa-py/protocols/usbutil.py
+++ b/pyvisa-py/protocols/usbutil.py
@@ -120,10 +120,6 @@ AllCodes = {
 }
 
 
-class LantzUSBTimeoutError(usb.core.USBError):
-    pass
-
-
 def ep_attributes(ep):
     c = ep.bmAttributes
     attrs = []
@@ -136,7 +132,7 @@ def ep_attributes(ep):
         attrs.append('Bulk')
     elif tp == usb.ENDPOINT_TYPE_INTERRUPT:
         attrs.append('Interrupt')
-        
+
     sync = (c & 12) >> 2
     if sync == 0:
         attrs.append('No sync')
@@ -159,7 +155,8 @@ def ep_attributes(ep):
     return ', '.join(attrs)
 
 
-def find_devices(vendor=None, product=None, serial_number=None, custom_match=None, **kwargs):
+def find_devices(vendor=None, product=None, serial_number=None,
+                 custom_match=None, **kwargs):
     """Find connected USB devices matching certain keywords.
 
     Wildcards can be used for vendor, product and serial_number.

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -10,7 +10,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import abc
 import time
@@ -21,6 +22,7 @@ from . import common
 
 
 StatusCode = constants.StatusCode
+
 
 class UnknownAttribute(Exception):
 
@@ -197,14 +199,14 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         It is also possible to change handling of already registerd common attributes. List of attributes is available in pyvisa package:
         * name is in constants module as: VI_ATTR_<NAME>
         * validity of attribute for resource is defined module attributes, AttrVI_ATTR_<NAME>.resources
-       
+
         For static (read only) values, simple readonly and also readwrite attributes simplified construction can be used:
         `    self.attrs[constants.VI_ATTR_<NAME>] = 100`
         or
         `    self.attrs[constants.VI_ATTR_<NAME>] = <self.variable_name>`
-        
+
         For more complex handling of attributes, it is possible to register getter and/or setter. When Null is used, NotSupported error is returned.
-        Getter has same signature as see Session._get_attribute and setter has same signature as see Session._set_attribute. (It is possible to register also 
+        Getter has same signature as see Session._get_attribute and setter has same signature as see Session._set_attribute. (It is possible to register also
         see Session._get_attribute and see Session._set_attribute as getter/setter). Getter and Setter are registered as tupple.
         For readwrite attribute:
         `    self.attrs[constants.VI_ATTR_<NAME>] = (<getter_name>, <setter_name>)`
@@ -329,17 +331,19 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :rtype: bytes, constants.StatusCode
         """
 
-        # NOTE: Some interfaces return not only a single byte but a complete block for each read
-        # therefore we must handle the case that the termination character is in the middle of the  block
-        # or that the maximum number of bytes is exceeded
+        # NOTE: Some interfaces return not only a single byte but a complete
+        # block for each read therefore we must handle the case that the
+        # termination character is in the middle of the  block or that the
+        # maximum number of bytes is exceeded
 
         # Make sure termination_char is a string
         try:
-             termination_char = chr(termination_char)
+            termination_char = chr(termination_char)
         except TypeError:
             pass
 
-        finish_time = None if self.timeout is None else (time.time() + self.timeout)
+        finish_time = (None if self.timeout is None else
+                       (time.time() + self.timeout))
         out = b''
         while True:
             try:
@@ -357,18 +361,21 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                 else:
                     if termination_char_en and termination_char in current:
                         # RULE 6.1.2
-                        # Return everything upto and including the termination character
-                        return out[:out.index(termination_char)+1], StatusCode.success_termination_character_read
+                        # Return everything upto and including the termination
+                        # character
+                        return (out[:out.index(termination_char)+1],
+                                StatusCode.success_termination_character_read)
                     elif len(out) >= count:
                         # RULE 6.1.3
                         # Return at most the number of bytes requested
                         return out[:count], StatusCode.success_max_count_read
 
-            if finish_time and time.time() > finish_timeout:
+            if finish_time and time.time() > finish_time:
                 return out, StatusCode.error_timeout
 
     def _get_timeout(self, attribute):
         """  Returns timeout calculated value from python way to VI_ way
+
         """
         if self.timeout is None:
             ret_value = constants.VI_TMO_INFINITE

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -27,8 +27,9 @@ StatusCode = constants.StatusCode
 
 @Session.register(constants.InterfaceType.tcpip, 'INSTR')
 class TCPIPInstrSession(Session):
-    """A TCPIP Session that uses the network standard library to do the low level communication
-    using VXI-11
+    """A TCPIP Session that uses the network standard library to do the low
+    level communication using VXI-11
+
     """
 
     lock_timeout = 1000
@@ -88,7 +89,6 @@ class TCPIPInstrSession(Session):
 
         if self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)[0]:
             term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
-            term_char = str(term_char).encode('utf-8')[0]
             flags = vxi11.OP_FLAG_TERMCHAR_SET
         else:
             term_char = flags = 0
@@ -98,6 +98,8 @@ class TCPIPInstrSession(Session):
 
         read_data = bytearray()
         reason = 0
+        # Stop on end of message or when a termination character has been
+        # encountered.
         end_reason = vxi11.RX_END | vxi11.RX_CHR
         read_fun = self.interface.device_read
         status = StatusCode.success
@@ -448,7 +450,7 @@ class TCPIPSocketSession(Session):
                     out = bytes(self._pending_buffer[:count])
                     self._pending_buffer = self._pending_buffer[count:]
                     return out, StatusCode.succes
-    
+
                 if finish_time and time.time() >= finish_time:
                     # reached timeout
                     out = bytes(self._pending_buffer[:count])


### PR DESCRIPTION
The term char was incorrectly converted, which lead to read incomplete messages.
Also optimize some routines to use bytearray and some general pep 8 formatting, and prevent a hard fail if one instrument connected in USB is not properly configured (can happen on windows with the wrong driver installed)

@skrchnavy if you have time to review it would be nice. This fixes the issue I have seen in #120 .