### PR TITLE
tcpip: INSTR proper Visa timeout error on timeout

### DIFF
--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -477,7 +477,8 @@ class RawTCPClient(Client):
 
 
 class RawUDPClient(Client):
-    """Client using UDP to a specific port
+    """Client using UDP to a specific port.
+
     """
     def __init__(self, host, prog, vers, port):
         Client.__init__(self, host, prog, vers, port)

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -17,6 +17,7 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 import enum
+import socket
 
 from . import rpc
 
@@ -208,17 +209,23 @@ class CoreClient(rpc.TCPClient):
 
     def device_write(self, link, io_timeout, lock_timeout, flags, data):
         params = (link, io_timeout, lock_timeout, flags, data)
-        return self.make_call(DEVICE_WRITE, params,
-                              self.packer.pack_device_write_parms,
-                              self.unpacker.unpack_device_write_resp)
+        try:
+            return self.make_call(DEVICE_WRITE, params,
+                                  self.packer.pack_device_write_parms,
+                                  self.unpacker.unpack_device_write_resp)
+        except socket.timeout as e:
+            return ErrorCodes.io_timeout, e.args[0], ''
 
     def device_read(self, link, request_size, io_timeout, lock_timeout, flags,
                     term_char):
         params = (link, request_size, io_timeout, lock_timeout, flags,
                   term_char)
-        return self.make_call(DEVICE_READ, params,
-                              self.packer.pack_device_read_parms,
-                              self.unpacker.unpack_device_read_resp)
+        try:
+            return self.make_call(DEVICE_READ, params,
+                                  self.packer.pack_device_read_parms,
+                                  self.unpacker.unpack_device_read_resp)
+        except socket.timeout as e:
+            return ErrorCodes.io_timeout, e.args[0], ''
 
     def device_read_stb(self, link, flags, lock_timeout, io_timeout):
         params = (link, flags, lock_timeout, io_timeout)


### PR DESCRIPTION
Previously the socket error was bubbling up to the user which was not nice. I am not sure this is the proper way to do it but I do not see how to do it in a protocol independent fashion at the rpc level.