### PR TITLE
Attempt to fix an issue in rpc in which a select timeout cause a EOFError

### DIFF
--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -353,6 +353,9 @@ def _recvrecord(sock, timeout, read_fun=None):
             buffer.extend(read_data)
         elif timeout is not None and time.time() >= finish_time:
             # reached timeout
+            logger.debug(('Time out encountered in %s.'
+                          'Buffer %r, partial record %r'),
+                         sock, buffer, record)
             msg = ("socket.timeout: The instrument seems to have stopped "
                    "responding.")
             raise socket.timeout(msg)
@@ -363,7 +366,7 @@ def _recvrecord(sock, timeout, read_fun=None):
             continue
 
         if wait_header:
-            # need tofind header
+            # need to find header
             if len(buffer) >= exp_length:
                 header = buffer[:exp_length]
                 buffer = buffer[exp_length:]

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -351,19 +351,16 @@ def _recvrecord(sock, timeout, read_fun=None):
         if sock in r:
             read_data = read_fun(exp_length)
             buffer.extend(read_data)
-
-        if not read_data:
-            if timeout is not None and time.time() >= finish_time:
-                # reached timeout
-                msg = ("socket.timeout: The instrument seems to have stopped "
-                       "responding.")
-                raise socket.timeout(msg)
-            if record or not wait_header:
-                # received some data or header
-                raise EOFError
+        elif timeout is not None and time.time() >= finish_time:
+            # reached timeout
+            msg = ("socket.timeout: The instrument seems to have stopped "
+                   "responding.")
+            raise socket.timeout(msg)
+        else:
             # `select_timout` decreased to 50% of previous or
             # min_select_timeout
             select_timout = max(select_timout/2.0, min_select_timeout)
+            continue
 
         if wait_header:
             # need tofind header

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -374,9 +374,6 @@ def _recvrecord(sock, timeout, read_fun=None):
                 x = struct.unpack(">I", header)[0]
                 last = ((x & 0x80000000) != 0)
                 exp_length = int(x & 0x7fffffff)
-                # XXX remove this in final version of the patch
-                logger.debug('Found header. Expecting %d bytes. Last fragment '
-                             'of the record: %s', exp_length, bool(last))
                 wait_header = False
         else:
             if len(buffer) >= exp_length:

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -354,8 +354,9 @@ def _recvrecord(sock, timeout, read_fun=None):
         elif timeout is not None and time.time() >= finish_time:
             # reached timeout
             logger.debug(('Time out encountered in %s.'
-                          'Buffer %r, partial record %r'),
-                         sock, buffer, record)
+                          'Already receieved %d bytes. Last fragment is %d '
+                          'bytes long and we were expecting %d'),
+                         sock, len(record), len(buffer), exp_length)
             msg = ("socket.timeout: The instrument seems to have stopped "
                    "responding.")
             raise socket.timeout(msg)
@@ -373,6 +374,9 @@ def _recvrecord(sock, timeout, read_fun=None):
                 x = struct.unpack(">I", header)[0]
                 last = ((x & 0x80000000) != 0)
                 exp_length = int(x & 0x7fffffff)
+                # XXX remove this in final version of the patch
+                logger.debug('Found header. Expecting %d bytes. Last fragment '
+                             'of the record: %s', exp_length, bool(last))
                 wait_header = False
         else:
             if len(buffer) >= exp_length:

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -102,7 +102,12 @@ class TCPIPInstrSession(Session):
         status = StatusCode.success
 
         timeout = int(self.timeout*1000) if self.timeout else 2**32-1
+        start_time = time.monotonic()
         while reason & end_reason == 0:
+            # Decrease timeout so that the total timeout does not get larger
+            # than the specified timeout.
+            timeout = max(0,
+                          timeout - int((time.monotonic() - start_time)*1000))
             error, reason, data = read_fun(self.link, chunk_length,
                                            timeout,
                                            self.lock_timeout, flags, term_char)


### PR DESCRIPTION
The basic idea is that compared to the old version (pre PR 67), we can now get an empty read_data because the select timed out, which by itself may no mean anything, and we need to wait to see if we get a real timeout rather than complaining about EOFError early.

@svanan77 could you review and test. Hopefully this should fix https://github.com/pyvisa/pyvisa/issues/319 and given the nature of the issue, it is possible I could not easily reproduce locally.