### PR TITLE
fix gpib

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -185,7 +185,7 @@ class GPIBSession(Session):
 
         try:
             self.interface.clear()
-            return SUCCESS
+            return 0, StatusCode.success
         except:
             return 0, StatusCode.error_system_error
 
@@ -203,7 +203,7 @@ class GPIBSession(Session):
 
         try:
             self.controller.interface_clear()
-            return SUCCESS
+            return 0, StatusCode.success
         except:
             return 0, StatusCode.error_system_error
 

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -10,7 +10,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-import sys
 from __future__ import division, unicode_literals, print_function, absolute_import
 from bisect import bisect
 
@@ -142,10 +141,7 @@ class GPIBSession(Session):
         # 0x2000 = 8192 = END
         checker = lambda current: self.interface.ibsta() & 8192
 
-        if sys.version_info >= (3, 0):
-            reader = lambda: self.interface.read(count)
-        else:
-            reader = lambda: self.interface.read(count).encode('ascii')
+        reader = lambda: self.interface.read(count)
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -10,6 +10,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import sys
 from __future__ import division, unicode_literals, print_function, absolute_import
 from bisect import bisect
 
@@ -141,7 +142,10 @@ class GPIBSession(Session):
         # 0x2000 = 8192 = END
         checker = lambda current: self.interface.ibsta() & 8192
 
-        reader = lambda: self.interface.read(count)
+        if sys.version_info >= (3, 0):
+            reader = lambda: self.interface.read(count)
+        else:
+            reader = lambda: self.interface.read(count).encode('ascii')
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -71,8 +71,8 @@ class GPIBSession(Session):
         timeout = 13
         send_eoi = 1
         eos_mode = 0
-        self.interface = Gpib(name = minor, pad = pad, sad = sad, timeout = timeout, send_eoi = send_eoi, eos_mode = eos_mode)
-        self.controller = Gpib(name = minor) # this is the bus controller device
+        self.interface = Gpib(name=minor, pad=pad, sad=sad, timeout=timeout, send_eoi=send_eoi, eos_mode=eos_mode)
+        self.controller = Gpib(name=minor) # this is the bus controller device
         self.handle = self.interface.id
         # force timeout setting to interface
         self.set_attribute(constants.VI_ATTR_TMO_VALUE, attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default)

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -194,6 +194,38 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         return self._register(sess), StatusCode.success
 
+    def clear(self, session):
+        """Clears a device.
+
+        Corresponds to viClear function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            self.sessions[session].clear()
+            return constants.StatusCode.success
+
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+
+    def gpib_send_ifc(self, session):
+        """Pulse the interface clear line (IFC) for at least 100 microseconds.
+
+        Corresponds to viGpibSendIFC function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            self.sessions[session].gpib_send_ifc()
+            return constants.StatusCode.success
+
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+
     def close(self, session):
         """Closes the specified session, event, or find list.
 
@@ -280,7 +312,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         if ret[1] < 0:
             raise errors.VisaIOError(ret[1])
 
-        return ret
+        return ret[0] # return number of bytes written
 
     def get_attribute(self, session, attribute):
         """Retrieves the state of an attribute.

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -312,7 +312,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         if ret[1] < 0:
             raise errors.VisaIOError(ret[1])
 
-        return ret[0] # return number of bytes written
+        return ret
 
     def get_attribute(self, session, attribute):
         """Retrieves the state of an attribute.

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -244,6 +244,27 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         """
         pass
 
+    def gpib_send_ifc(self):
+        """Pulse the interface clear line (IFC) for at least 100 microseconds.
+
+        Corresponds to viGpibSendIFC function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+
+    def clear(self):
+        """Clears a device.
+
+        Corresponds to viClear function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+
+
     def get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -253,6 +253,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :return: return value of the library call.
         :rtype: :class:`pyvisa.constants.StatusCode`
         """
+        return StatusCode.error_nonsupported_operation
 
     def clear(self):
         """Clears a device.
@@ -263,7 +264,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         :return: return value of the library call.
         :rtype: :class:`pyvisa.constants.StatusCode`
         """
-
+        return StatusCode.error_nonsupported_operation
 
     def get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.


### PR DESCRIPTION
These changes fix gpib and implement the highlevel `gpib_send_ifc` and `clear` functions.

I've tested this with the latest linux-gpib from svn (the only way currently to get it working with Linux version 4.15.15) on a Keithley 2400 sourcemeter via a GPIB-USB-HS adapter.

I also tested it with the serial interface to make sure I didn't break anything there.