### PR TITLE
sessions: pass the timeout value when creating a USB interface.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@ PyVISA-py Changelog
 0.4.0 (unreleased)
 ------------------
 
-
+- fix initialization of timeout for the USB resources (the default was set
+  before creating the underlying connection to which the timeout must be passed
+  and was not). PR #167
 
 0.3.1 (2018-09-12)
 ------------------

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -12,7 +12,7 @@
 
     This file is an offspring of the Lantz Project.
 
-    :copyright: 2014 by PyVISA-py Authors, see AUTHORS for more details.
+    :copyright: 2014-2018 by PyVISA-py Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -150,8 +150,6 @@ class USBRaw(object):
     #: Receive and Send endpoints to be used. If None the first IN (or OUT)
     #: BULK endpoint will be used.
     ENDPOINTS = (None, None)
-
-    timeout = 2000
 
     find_devices = staticmethod(find_devices)
 

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -157,6 +157,8 @@ class USBRaw(object):
                  device_filters=None, timeout=None, **kwargs):
         super(USBRaw, self).__init__()
 
+        # Timeout expressed in ms as an integer and limited to 2**32-1
+        # If left to None pyusb will use its default value
         self.timeout = timeout
 
         device_filters = device_filters or {}

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -205,8 +205,9 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                       constants.VI_ATTR_TMO_VALUE: (self._get_timeout,
                                                     self._set_timeout)}
 
-        #: Timeout in the interface format. A meaningful value is attributed
-        #: to it when calling self.set_attribute(attr, default_timeout)
+        #: Timeout expressed in second or None for the absence of a timeout.
+        #: The default value is set when calling
+        #: self.set_attribute(attr, default_timeout)
         self.timeout = None
 
         #: Set the default timeout from constants

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -6,7 +6,7 @@
     Base Session class.
 
 
-    :copyright: 2014 by PyVISA-py Authors, see AUTHORS for more details.
+    :copyright: 2014-2018 by PyVISA-py Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -204,6 +204,10 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
                       constants.VI_ATTR_INTF_TYPE: parsed.interface_type,
                       constants.VI_ATTR_TMO_VALUE: (self._get_timeout,
                                                     self._set_timeout)}
+
+        #: Timeout in the interface format. A meaningful value is attributed
+        #: to it when calling self.set_attribute(attr, default_timeout)
+        self.timeout = None
 
         #: Set the default timeout from constants
         attr = constants.VI_ATTR_TMO_VALUE

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -6,7 +6,7 @@
     Serial Session implementation using PyUSB.
 
 
-    :copyright: 2014 by PyVISA-py Authors, see AUTHORS for more details.
+    :copyright: 2014-2018 by PyVISA-py Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -197,7 +197,8 @@ class USBInstrSession(USBSession):
     def after_parsing(self):
         self.interface = usbtmc.USBTMC(int(self.parsed.manufacturer_id, 0),
                                        int(self.parsed.model_code, 0),
-                                       self.parsed.serial_number)
+                                       self.parsed.serial_number,
+                                       timeout=self.timeout)
 
         for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
@@ -244,7 +245,8 @@ class USBRawSession(USBSession):
     def after_parsing(self):
         self.interface = usbraw.USBRawDevice(int(self.parsed.manufacturer_id, 0),
                                              int(self.parsed.model_code, 0),
-                                             self.parsed.serial_number)
+                                             self.parsed.serial_number,
+                                             timeout=self.timeout)
 
         for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -197,10 +197,9 @@ class USBInstrSession(USBSession):
     def after_parsing(self):
         self.interface = usbtmc.USBTMC(int(self.parsed.manufacturer_id, 0),
                                        int(self.parsed.model_code, 0),
-                                       self.parsed.serial_number,
-                                       timeout=self.timeout)
+                                       self.parsed.serial_number)
 
-        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
+        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'TMO_VALUE'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
@@ -245,9 +244,8 @@ class USBRawSession(USBSession):
     def after_parsing(self):
         self.interface = usbraw.USBRawDevice(int(self.parsed.manufacturer_id, 0),
                                              int(self.parsed.model_code, 0),
-                                             self.parsed.serial_number,
-                                             timeout=self.timeout)
+                                             self.parsed.serial_number)
 
-        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
+        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'TMO_VALUE'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default


### PR DESCRIPTION
Proper fix for #166 

@mgubser could you please review and test.