### PR TITLE
usbtmc: convert possible float to int

### DIFF
--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -157,7 +157,7 @@ class USBRaw(object):
                  device_filters=None, timeout=None, **kwargs):
         super(USBRaw, self).__init__()
 
-        self.timeout = timeout
+        self.timeout = int(timeout)
 
         device_filters = device_filters or {}
         devices = list(self.find_devices(vendor, product, serial_number, None,


### PR DESCRIPTION
``libusb``'s ``control_transfer()`` requires an (unsigned) int as type of ``timeout``. Or do we want to keep the float as long as possible and only convert it upon passing it to the mentioned function?