### PR TITLE
fix double close of GPIB interface and controller in GpibSession

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -73,7 +73,6 @@ class GPIBSession(Session):
         eos_mode = 0
         self.interface = Gpib(name=minor, pad=pad, sad=sad, timeout=timeout, send_eoi=send_eoi, eos_mode=eos_mode)
         self.controller = Gpib(name=minor) # this is the bus controller device
-        self.handle = self.interface.id
         # force timeout setting to interface
         self.set_attribute(constants.VI_ATTR_TMO_VALUE, attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default)
 
@@ -126,7 +125,10 @@ class GPIBSession(Session):
         return status
 
     def close(self):
-        gpib.close(self.handle)
+        del self.interface
+        del self.controller
+        self.interface = None
+        self.controller = None
 
     def read(self, count):
         """Reads data from device or interface synchronously.


### PR DESCRIPTION
Fix a double close of GPIB connections which usually produces uncaught exceptions.

To reproduce the bug on pyvisa-py master:
```python
$ ipython
Python 3.7.0 (default, Oct  9 2018, 10:31:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.1.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import visa                                                                                                                                                                                                                           

In [2]: rm = visa.ResourceManager('@py')                                                                                                                                                                                                      

In [3]: tek = rm.open_resource('GPIB0::30::INSTR')                                                                                                                                                                                            

In [4]: tek.query('*IDN?')                                                                                                                                                                                                                    
Out[4]: 'TEKTRONIX,TDS 3014C,0,CF:91.1CT FV:v4.05 TDS3GV:v1.00 TDS3FFT:v1.00 TDS3TRG:v1.00\n'

In [5]: quit()                                                                                                                                                                                                                                
libgpib: invalid descriptor
libgpib: invalid descriptor
Exception ignored in: <function Gpib.__del__ at 0x7f985e1996a8>
Traceback (most recent call last):
  File "/home/tivek/projects/linux-gpib-code/linux-gpib-user/language/python/Gpib.py", line 32, in __del__
gpib.GpibError: close() failed: One or more arguments to the function call were invalid.
```

Explanation and fix:
GpibSession uses two Gpib.Gpib objects (linux-gpib project) to manage connections to the instrument and GPIB board. These clean up on their own in `__del__()` and we should not manually close their handles.

Long-term, `__del__()` should not be used for reliable finalization since it is a potentially ugly implementation detail of CPython's GC. Sadly, Gpib.Gpib does not expose a better interface for cleanup. At some point we should either patch/fork Gpib.Gpib or switch to classic gpib function calls with integer handles.