### PR TITLE
rpc: fix behavior after a normal timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _test/
 .mypy_cache/
 .pytest_cache/
 .cache/
+.vscode

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA-py Changelog
 0.4.0 (unreleased)
 ------------------
 
-- fix wrong increment of lastxid in rpc in the case of timeout PR # 173
+- fix improper wait time before a timeout in the TCPIP backend PR # 173
 - add GPIB support for proprietary device drivers on Windows and Linux
   (experimental): try importing gpib-ctypes if linux-gpib is not present.
   fix #105 #137

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.4.0 (unreleased)
 ------------------
 
+- fix wrong increment of lastxid in rpc in the case of timeout PR # 173
 - fix return types of PyVisaLibrary and Session methods to match
   pyvisa.highlevel.VisaLibraryBase fix #169 PR #170
 - avoid double closing of gpib resources PR #171

--- a/pyvisa-py/__init__.py
+++ b/pyvisa-py/__init__.py
@@ -6,7 +6,7 @@
     Pure Python backend for PyVISA.
 
 
-    :copyright: 2014 by PyVISA-py Authors, see AUTHORS for more details.
+    :copyright: 2014-2019 by PyVISA-py Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -321,7 +321,7 @@ def _sendrecord(sock, record, fragsize=None, timeout=None):
         record = record[fragsize:]
 
 
-def _recvrecord(sock, timeout, read_fun=None, client=None):
+def _recvrecord(sock, timeout, read_fun=None):
 
     record = bytearray()
     buffer = bytearray()
@@ -353,11 +353,6 @@ def _recvrecord(sock, timeout, read_fun=None, client=None):
             buffer.extend(read_data)
         # Timeout was reached
         elif timeout is not None and time.time() >= finish_time:
-            # In the total absence of answer from the instrument we can assume
-            # that xid should not be incremented since the instrument did not
-            # acknowledge the communication.
-            if not read_data:
-                client.lastxid -= 1
             logger.debug(('Time out encountered in %s.'
                           'Already receieved %d bytes. Last fragment is %d '
                           'bytes long and we were expecting %d'),
@@ -478,7 +473,7 @@ class RawTCPClient(Client):
 
         _sendrecord(self.sock, call, timeout=self.timeout)
 
-        reply = _recvrecord(self.sock, self.timeout, client=self)
+        reply = _recvrecord(self.sock, self.timeout)
         u = self.unpacker
         u.reset(reply)
         xid, verf = u.unpack_replyheader()

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -453,6 +453,12 @@ class RawTCPClient(Client):
         else:
             self.timeout = 4.0
 
+        # In case of a timeout because the instrument cannot answer, the
+        # instrument should let use something went wrong. If we hit the hard
+        # timeout of the rpc, it means something worse happened (cable
+        # unplugged).
+        self.timeout += 1.0
+
         return super(RawTCPClient, self).make_call(proc, args, pack_func,
                                                    unpack_func)
 

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -217,7 +217,7 @@ class CoreClient(rpc.TCPClient):
                                   self.packer.pack_device_write_parms,
                                   self.unpacker.unpack_device_write_resp)
         except socket.timeout as e:
-            return ErrorCodes.io_error, e.args[0], ''
+            return ErrorCodes.io_error, e.args[0]
 
     def device_read(self, link, request_size, io_timeout, lock_timeout, flags,
                     term_char):

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -203,9 +203,12 @@ class CoreClient(rpc.TCPClient):
 
     def create_link(self, id, lock_device, lock_timeout, name):
         params = (id, lock_device, lock_timeout, name)
-        return self.make_call(CREATE_LINK, params,
-                              self.packer.pack_create_link_parms,
-                              self.unpacker.unpack_create_link_resp)
+        try:
+            return self.make_call(CREATE_LINK, params,
+                                self.packer.pack_create_link_parms,
+                                self.unpacker.unpack_create_link_resp)
+        except socket.timeout as e:
+            return ErrorCodes.device_not_accessible, None, None, None
 
     def device_write(self, link, io_timeout, lock_timeout, flags, data):
         params = (link, io_timeout, lock_timeout, flags, data)
@@ -214,7 +217,7 @@ class CoreClient(rpc.TCPClient):
                                   self.packer.pack_device_write_parms,
                                   self.unpacker.unpack_device_write_resp)
         except socket.timeout as e:
-            return ErrorCodes.io_timeout, e.args[0], ''
+            return ErrorCodes.io_error, e.args[0], ''
 
     def device_read(self, link, request_size, io_timeout, lock_timeout, flags,
                     term_char):
@@ -225,7 +228,7 @@ class CoreClient(rpc.TCPClient):
                                   self.packer.pack_device_read_parms,
                                   self.unpacker.unpack_device_read_resp)
         except socket.timeout as e:
-            return ErrorCodes.io_timeout, e.args[0], ''
+            return ErrorCodes.io_error, e.args[0], ''
 
     def device_read_stb(self, link, flags, lock_timeout, io_timeout):
         params = (link, flags, lock_timeout, io_timeout)

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -60,8 +60,11 @@ class TCPIPInstrSession(Session):
         # TODO: board_number not handled
         # TODO: lan_device_name not handled
         # vx11 expect all timeouts to be expressed in ms and should be integers
-        self.interface = vxi11.CoreClient(self.parsed.host_address,
-                                          self.open_timeout)
+        try:
+            self.interface = vxi11.CoreClient(self.parsed.host_address,
+                                              self.open_timeout)
+        except rpc.RPCError:
+            raise errors.VisaIOError(constants.VI_ERROR_RSRC_NFOUND)
 
         self.max_recv_size = 1024
         self.lock_timeout = 10000


### PR DESCRIPTION
In the absence of any answer from the instrument we can assume that actually the instrument did not acknowledge the communication as valid. In which case the xid should not be incremented.

I also removed the offset on the timeout that were used before we properly implement the timeout mechanism.

@ldpgh could you please check this fixes the issue you are seeing ?