### PR TITLE
Fix custom USB timeout and recover after USBTMC timeout

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ PyVISA-py Changelog
 - fix initialization of timeout for the USB resources (the default was set
   before creating the underlying connection to which the timeout must be passed
   and was not). PR #167
+- implement USBTMC abort sequence after read timeout to avoid losing
+  communication with the instrument after a timeout occurs. PR #179
+- fix custom timeout for USB instruments. PR #179
 
 0.3.1 (2018-09-12)
 ------------------

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -307,6 +307,10 @@ class USBTMC(USBRaw):
         abort_timeout_ms = 5000
 
         # Send INITIATE_ABORT_BULK_IN.
+        # According to USBTMC 1.00 4.2.1.4:
+        #   wValue = bTag value of transfer to be aborted
+        #   wIndex = Bulk-IN endpoint
+        #   wLength = 0x0002 (length of device response)
         data = self.usb_dev.ctrl_transfer(
             usb.util.build_request_type(usb.util.CTRL_IN,
                                         usb.util.CTRL_TYPE_CLASS,
@@ -324,7 +328,11 @@ class USBTMC(USBRaw):
         # Read remaining data from Bulk-IN endpoint.
         self.usb_recv_ep.read(self.RECV_CHUNK, abort_timeout_ms)
 
-        # Send CHECK_ABORT_BULK_IN until it completes.
+        # Send CHECK_ABORT_BULK_IN_STATUS until it completes.
+        # According to USBTMC 1.00 4.2.1.5:
+        #   wValue = 0x0000
+        #   wIndex = Bulk-IN endpoint
+        #   wLength = 0x0008 (length of device response)
         for retry in range(100):
             data = self.usb_dev.ctrl_transfer(
                 usb.util.build_request_type(usb.util.CTRL_IN,

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -233,7 +233,10 @@ class USBRaw(object):
         :type data: bytes
         """
 
-        return self.usb_send_ep.write(data)
+        try:
+            return self.usb_send_ep.write(data)
+        except usb.core.USBError as e:
+            raise ValueError(str(e))
 
     def read(self, size):
         """Receive raw bytes to the instrument.

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -229,7 +229,8 @@ class USBInstrSession(USBSession):
 
         for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'TMO_VALUE'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
-            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+            self.set_attribute(attribute,
+                               attributes.AttributesByID[attribute].default)
 
 
 @Session.register(constants.InterfaceType.usb, 'RAW')
@@ -276,4 +277,5 @@ class USBRawSession(USBSession):
 
         for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN', 'TMO_VALUE'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
-            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+            self.set_attribute(attribute,
+                               attributes.AttributesByID[attribute].default)

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -219,6 +219,7 @@ class USBInstrSession(USBSession):
         except usb.USBError as exc:
             if exc.errno in (errno.ETIMEDOUT, -errno.ETIMEDOUT):
                 return bytes(), StatusCode.error_timeout
+            raise
 
         return bytes(data), StatusCode.success
 


### PR DESCRIPTION
48ef42325506da999e976c0cfe67e79f9bdc1eab implements an USBTMC abort sequence after a read timeout.
Similar abort sequences are used by python-usbtmc and NI-VISA to recover after a read timeout.
Also improves a few specific USBTMC technicalities.
Fixes #177.

cdc3e47912349d08a4eda58eb8676b8c4a4fa442 fixes a bug in custom timeout handling for USB instruments.
Fixes #178.