### PR TITLE
fix triggering

### DIFF
--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -238,7 +238,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         :rtype: :class:`pyvisa.constants.StatusCode`
         """
         try:
-            return self.sessions[session].trigger(protocol)
+            return self.sessions[session].assert_trigger(protocol)
 
         except KeyError:
             return constants.StatusCode.error_invalid_object


### PR DESCRIPTION
This fixes the `assert_trigger` highlevel.py function so that it calls the proper trigger function name in the lower level bits.

Tested with gpib. Should also fix other protocols that use triggering too, like tcpip