### PR TITLE
Add support GPIB INTFC

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -354,9 +354,8 @@ class _GPIBCommon(object):
                 return constants.VI_FALSE, StatusCode.success
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
-            # replace IbaEndBitIsNormal 0x1a
-	    # IbcEndBitIsNormal relates to EOI on read()
-            # not write(). see issue #196
+            # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read() 
+            # not write(). see issue #196 
             # IbcEOT 0x4
             if ifc.ask(4):
                 return constants.VI_TRUE, StatusCode.success
@@ -424,9 +423,8 @@ class _GPIBCommon(object):
                 return StatusCode.error_nonsupported_attribute_state
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
-            # replace IbaEndBitIsNormal 0x1a
-	    # IbcEndBitIsNormal relates to EOI on read()
-            # not write()
+            # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read() 
+            # not write(). see issue #196 
             # IbcEOT 0x4
             if isinstance(attribute_state, int):
                 ifc.config(4, attribute_state)
@@ -503,7 +501,6 @@ class GPIBInterface(_GPIBCommon, Session):
         return ['GPIB0::%d::INTFC' % pad for pad in _find_listeners()]
 
     def after_parsing(self):
-        logger.debug("PARSED: ", self.parsed)
         minor = int(self.parsed.board)
         sad = 0
         timeout = 13
@@ -528,7 +525,7 @@ class GPIBInterface(_GPIBCommon, Session):
         :rtype: int, :class:`pyvisa.constants.StatusCode`
         """
         try:
-            return self.controller.command(data), StatusCode.success
+            return self.controller.command(command_bytes), StatusCode.success
         except gpib.GpibError:
             return 0, convert_gpib_status(self.interface.ibsta())
 
@@ -545,7 +542,7 @@ class GPIBInterface(_GPIBCommon, Session):
         try:
             self.controller.interface_clear()
             return StatusCode.success
-        except gpib.GpibError:
+        except gpib.GpibError as e:
             return convert_gpib_error(e, self.interface.ibsta(), 'send IFC')
 
     def gpib_control_atn(self, mode):

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -156,6 +156,11 @@ class _GPIBCommon(object):
         self.set_attribute(constants.VI_ATTR_TMO_VALUE,
                            attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default)
 
+        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
+            attribute = getattr(constants, 'VI_ATTR_' + name)
+            self.attrs[attribute] =\
+                attributes.AttributesByID[attribute].default
+
     def _get_timeout(self, attribute):
         if self.interface:
             # 0x3 is the hexadecimal reference to the IbaTMO (timeout) configuration
@@ -350,8 +355,8 @@ class _GPIBCommon(object):
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
             # replace IbaEndBitIsNormal 0x1a
-	    # IbcEndBitIsNormal relates to EOI on read() 
-            # not write(). see issue #196 
+	    # IbcEndBitIsNormal relates to EOI on read()
+            # not write(). see issue #196
             # IbcEOT 0x4
             if ifc.ask(4):
                 return constants.VI_TRUE, StatusCode.success
@@ -420,8 +425,8 @@ class _GPIBCommon(object):
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
             # replace IbaEndBitIsNormal 0x1a
-	    # IbcEndBitIsNormal relates to EOI on read() 
-            # not write() 
+	    # IbcEndBitIsNormal relates to EOI on read()
+            # not write()
             # IbcEOT 0x4
             if isinstance(attribute_state, int):
                 ifc.config(4, attribute_state)

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -22,6 +22,7 @@ try:
     GPIB_CTYPES = True
     from gpib_ctypes import gpib
     from gpib_ctypes.Gpib import Gpib
+    from gpib_ctypes.gpib.gpib import _lib as gpib_lib
 
     # Add some extra binding not available by default
     extra_funcs = [
@@ -32,7 +33,7 @@ try:
         ("ibpct", [ctypes.c_int], ctypes.c_int),
     ]
     for name, argtypes, restype in extra_funcs:
-        libfunction = gpib._lib[name]
+        libfunction = gpib_lib[name]
         libfunction.argtypes = argtypes
         libfunction.restype = restype
 

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -223,7 +223,6 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         """
         try:
             return self.sessions[session].gpib_command(command_byte)
-
         except KeyError:
             return constants.StatusCode.error_invalid_object
 
@@ -239,7 +238,6 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         """
         try:
             return self.sessions[session].assert_trigger(protocol)
-
         except KeyError:
             return constants.StatusCode.error_invalid_object
 
@@ -257,6 +255,60 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         except KeyError:
             return constants.StatusCode.error_invalid_object
         return sess.gpib_send_ifc()
+
+    def gpib_control_ren(self, session, mode):
+        """Controls the state of the GPIB Remote Enable (REN) interface line, and optionally the remote/local
+        state of the device.
+
+        Corresponds to viGpibControlREN function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param mode: Specifies the state of the REN line and optionally the device remote/local state.
+                     (Constants.VI_GPIB_REN*)
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+        return sess.gpib_control_ren()
+
+    def gpib_control_atn(self, session, mode):
+        """Specifies the state of the ATN line and the local active controller state.
+
+        Corresponds to viGpibControlATN function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param mode: Specifies the state of the ATN line and optionally the local active controller state.
+                     (Constants.VI_GPIB_ATN*)
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+        return sess.gpib_control_atn()
+
+    def gpib_pass_control(self, session, primary_address, secondary_address):
+        """Tell the GPIB device at the specified address to become controller in charge (CIC).
+
+        Corresponds to viGpibPassControl function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param primary_address: Primary address of the GPIB device to which you want to pass control.
+        :param secondary_address: Secondary address of the targeted GPIB device.
+                                  If the targeted device does not have a secondary address,
+                                  this parameter should contain the value Constants.VI_NO_SEC_ADDR.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+        return sess.gpib_pass_control()
 
     def read_stb(self, session):
         """Reads a status byte of the service request.
@@ -323,7 +375,6 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         :return: data read, return value of the library call.
         :rtype: bytes, VISAStatus
         """
-
         # from the session handle, dispatch to the read method of the session object.
         try:
             ret = self.sessions[session].read(count)
@@ -346,7 +397,6 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         :return: Number of bytes actually transferred, return value of the library call.
         :rtype: int, VISAStatus
         """
-
         # from the session handle, dispatch to the write method of the session object.
         try:
             ret = self.sessions[session].write(data)

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -254,40 +254,6 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def gpib_command(self, command_byte):
-        """Write GPIB command byte on the bus.
-
-        Corresponds to viGpibCommand function of the VISA library.
-        See: https://linux-gpib.sourceforge.io/doc_html/gpib-protocol.html#REFERENCE-COMMAND-BYTES
-
-        :param command_byte: command byte to send
-        :type command_byte: int, must be [0 255]
-        :return: Number of written bytes, return value of the library call.
-        :rtype: int, :class:`pyvisa.constants.StatusCode`
-        """
-        return 0, StatusCode.error_nonsupported_operation
-
-    def assert_trigger(self, protocol):
-        """Asserts software or hardware trigger.
-
-        Corresponds to viAssertTrigger function of the VISA library.
-
-        :param protocol: Trigger protocol to use during assertion. (Constants.PROT*)
-        :return: return value of the library call.
-        :rtype: :class:`pyvisa.constants.StatusCode`
-        """
-        raise NotImplementedError
-
-    def gpib_send_ifc(self):
-        """Pulse the interface clear line (IFC) for at least 100 microseconds.
-
-        Corresponds to viGpibSendIFC function of the VISA library.
-
-        :return: return value of the library call.
-        :rtype: :class:`pyvisa.constants.StatusCode`
-        """
-        return StatusCode.error_nonsupported_operation
-
     def clear(self):
         """Clears a device.
 
@@ -329,6 +295,79 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         Corresponds to viUnlock function of the VISA library.
 
         :param session: Unique logical identifier to a session.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        return StatusCode.error_nonsupported_operation
+
+    def gpib_command(self, command_byte):
+        """Write GPIB command byte on the bus.
+
+        Corresponds to viGpibCommand function of the VISA library.
+        See: https://linux-gpib.sourceforge.io/doc_html/gpib-protocol.html#REFERENCE-COMMAND-BYTES
+
+        :param command_byte: command byte to send
+        :type command_byte: int, must be [0 255]
+        :return: Number of written bytes, return value of the library call.
+        :rtype: int, :class:`pyvisa.constants.StatusCode`
+        """
+        return 0, StatusCode.error_nonsupported_operation
+
+    def assert_trigger(self, protocol):
+        """Asserts software or hardware trigger.
+
+        Corresponds to viAssertTrigger function of the VISA library.
+
+        :param protocol: Trigger protocol to use during assertion. (Constants.PROT*)
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        raise NotImplementedError
+
+    def gpib_send_ifc(self):
+        """Pulse the interface clear line (IFC) for at least 100 microseconds.
+
+        Corresponds to viGpibSendIFC function of the VISA library.
+
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        return StatusCode.error_nonsupported_operation
+
+    def gpib_control_ren(self, mode):
+        """Controls the state of the GPIB Remote Enable (REN) interface line, and optionally the remote/local
+        state of the device.
+
+        Corresponds to viGpibControlREN function of the VISA library.
+
+        :param mode: Specifies the state of the REN line and optionally the device remote/local state.
+                     (Constants.VI_GPIB_REN*)
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        return StatusCode.error_nonsupported_operation
+
+    def gpib_control_atn(self, mode):
+        """Specifies the state of the ATN line and the local active controller state.
+
+        Corresponds to viGpibControlATN function of the VISA library.
+
+        :param mode: Specifies the state of the ATN line and optionally the local active controller state.
+                     (Constants.VI_GPIB_ATN*)
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        return StatusCode.error_nonsupported_operation
+
+    def gpib_pass_control(self, primary_address, secondary_address):
+        """Tell the GPIB device at the specified address to become controller in charge (CIC).
+
+        Corresponds to viGpibPassControl function of the VISA library.
+
+        :param primary_address: Primary address of the GPIB device to which you want to pass control.
+        :param secondary_address: Secondary address of the targeted GPIB device.
+                                  If the targeted device does not have a secondary address,
+                                  this parameter should contain the value Constants.VI_NO_SEC_ADDR.
         :return: return value of the library call.
         :rtype: :class:`pyvisa.constants.StatusCode`
         """


### PR DESCRIPTION
This re-organizes the code that, before, was heavily mixing INSTR and INTFC capabilities. It also patches gpib_ctypes to provide some extra functions we need. https://github.com/tivek/gpib_ctypes/issues/3 tracks the issue that should also be discussed in linux-gpib.

This code has not been tested yet. Anybody that can help in testing that code is very welcome to do so. Note that to access all the new functionalities one needs gpib_ctypes since linux-gpib does not expose some functions to Python. The typical use case for those is described in: https://github.com/pyvisa/pyvisa/issues/400.

@jondoesntgit you may be interested in this. I did not implement the buffer_read/write mostly because I am not sure they are necessary. Using read should work (you have to go through the VISA library for the time being but I would be interested in discussing adding it to the resource since it is supposed to support it.