### PR TITLE
Fixes to handle interface reads and writes

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -229,11 +229,10 @@ class _GPIBCommon(object):
         ifc = self.interface or self.controller
 
         # END 0x2000
-
         checker = lambda current: ifc.ibsta() & 0x2000
 
         reader = lambda: ifc.read(count)
-        
+
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 
     def write(self, data):
@@ -254,7 +253,7 @@ class _GPIBCommon(object):
         try:
             ifc.write(data)
             count = ifc.ibcnt() # number of bytes transmitted
-            
+
             return count, StatusCode.success
         except gpib.GpibError as e:
             return 0, convert_gpib_error(e, ifc.ibsta(), 'write')
@@ -364,9 +363,9 @@ class _GPIBCommon(object):
                 return constants.VI_FALSE, StatusCode.success
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
-          # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read() 
-          # not write(). see issue #196 
-          # IbcEOT 0x4
+            # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read()
+            # not write(). see issue #196
+            # IbcEOT 0x4
             if ifc.ask(4):
                 return constants.VI_TRUE, StatusCode.success
             else:
@@ -432,8 +431,8 @@ class _GPIBCommon(object):
                 return StatusCode.error_nonsupported_attribute_state
 
         elif attribute == constants.VI_ATTR_SEND_END_EN:
-            # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read() 
-            # not write(). see issue #196 
+            # Do not use IbaEndBitIsNormal 0x1a which relates to EOI on read()
+            # not write(). see issue #196
             # IbcEOT 0x4
             if isinstance(attribute_state, int):
                 ifc.config(4, attribute_state)

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -408,6 +408,29 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         return ret
 
+    def buffer_read(self, session, count):
+        """Reads data from device or interface through the use of a formatted I/O read buffer.
+        Corresponds to viBufRead function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param count: Number of bytes to be read.
+        :return: data read, return value of the library call.
+        :rtype: bytes, VISAStatus
+        """
+        return self.read(session, count)
+
+    def buffer_write(self, session, data):
+        """Writes data to a formatted I/O write buffer synchronously.
+        Corresponds to viBufWrite function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param data: data to be written.
+        :type data: str
+        :return: Number of bytes actually transferred, return value of the library call.
+        :rtype: int, VISAStatus
+        """
+        return self.write(session, data)
+
     def get_attribute(self, session, attribute):
         """Retrieves the state of an attribute.
 


### PR DESCRIPTION
Fixed calls to directly imported library functions to use gpib_lib
Added support for buffer_read()/buffer_write() functions (just call read() and write() for now)
Fixed support  for read() and write() on interface objects

