### PR TITLE
Fixed exception on interface open caused by missing primary address

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -142,12 +142,12 @@ class _GPIBCommon(object):
 
     def after_parsing(self):
         minor = int(self.parsed.board)
-        pad = int(self.parsed.primary_address)
         sad = 0
         timeout = 13
         send_eoi = 1
         eos_mode = 0
         if self.parsed.resource_class == 'INSTR':
+            pad = int(self.parsed.primary_address)
             # Used to talk to a specific resource
             self.interface = Gpib(name=minor, pad=pad, sad=sad,
                                   timeout=timeout, send_eoi=send_eoi,

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -146,6 +146,7 @@ class _GPIBCommon(object):
         timeout = 13
         send_eoi = 1
         eos_mode = 0
+        self.interface = None
         if self.parsed.resource_class == 'INSTR':
             pad = int(self.parsed.primary_address)
             # Used to talk to a specific resource


### PR DESCRIPTION
This got missed when after_parsing was removed from the interface class