### PR TITLE
Removed SEND_END_EN from variable parameters

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -159,7 +159,7 @@ class _GPIBCommon(object):
         self.set_attribute(constants.VI_ATTR_TMO_VALUE,
                            attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default)
 
-        for name in ('SEND_END_EN', 'TERMCHAR', 'TERMCHAR_EN'):
+        for name in ('TERMCHAR', 'TERMCHAR_EN'):
             attribute = getattr(constants, 'VI_ATTR_' + name)
             self.attrs[attribute] =\
                 attributes.AttributesByID[attribute].default


### PR DESCRIPTION
This was hard to track down- adding `VI_ATTR_SEND_END_EN` to `self.attrs` disables attribute setting using` _set_attribute()` as it's now just a variable.

You can't set defaults this way except for attributes that are not implemented in `_set_attribute()`.