### PR TITLE
Adds functionality for multiple boards in one system, fixes lockup on scan

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -539,7 +539,7 @@ class GPIBInterface(_GPIBCommon, Session):
         try:
             return self.controller.command(command_bytes), StatusCode.success
         except gpib.GpibError as e:
-            return convert_gpib_error(e, self.interface.ibsta(), 'gpib command')
+            return convert_gpib_error(e, self.controller.ibsta(), 'gpib command')
 
     def gpib_send_ifc(self):
         """Pulse the interface clear line (IFC) for at least 100 microseconds.
@@ -555,7 +555,7 @@ class GPIBInterface(_GPIBCommon, Session):
             self.controller.interface_clear()
             return StatusCode.success
         except gpib.GpibError as e:
-            return convert_gpib_error(e, self.interface.ibsta(), 'send IFC')
+            return convert_gpib_error(e, self.controller.ibsta(), 'send IFC')
 
     def gpib_control_atn(self, mode):
         """Specifies the state of the ATN line and the local active controller state.

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -81,13 +81,12 @@ def _find_listeners():
     """Find GPIB listeners.
     """
     for board, boardpad in _find_boards():
-      try:
-        for i in range(31):
-          try:
-              if boardpad != i and gpib.listener(board, i):
-                  yield board, i
-          except gpib.GpibError as e:
-              logger.debug("GPIB board %i addr %i error in _find_listeners(): %s", board, i, repr(e))
+      for i in range(31):
+        try:
+          if boardpad != i and gpib.listener(board, i):
+            yield board, i
+        except gpib.GpibError as e:
+            logger.debug("GPIB board %i addr %i error in _find_listeners(): %s", board, i, repr(e))
 
 
 StatusCode = constants.StatusCode

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -72,12 +72,17 @@ BOARD = 0
 def _find_listeners():
     """Find GPIB listeners.
     """
-    for i in range(31):
-        try:
-            if gpib.listener(BOARD, i) and gpib.ask(BOARD, 1) != i:
-                yield i
-        except gpib.GpibError as e:
-            logger.debug("GPIB error in _find_listeners(): %s", repr(e))
+    for board in range(16):
+      try:
+        boardpad = gpib.ask(board, 1)
+        for i in range(31):
+          try:
+              if boardpad != i and gpib.listener(board, i):
+                  yield i
+          except gpib.GpibError as e:
+              logger.debug("GPIB board %i addr %i error in _find_listeners(): %s", board, i, repr(e))
+      except gpib.GpibError as e:
+           logger.debug("GPIB board %i error in _find_listeners(): %s", board,repr(e))
 
 
 StatusCode = constants.StatusCode

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -136,7 +136,14 @@ def convert_gpib_error(error, status, operation):
         else:
             return constants.StatusCode.error_system_error
 
-
+def convert_gpib_status(status):
+    if status & 0x4000:
+        return constants.StatusCode.error_timeout
+    elif status & 0x8000:
+      return constants.StatusCode.error_system_error
+    else:
+      return constants.StatusCode.success
+      
 class _GPIBCommon(object):
     """Common base class for GPIB sessions.
 
@@ -532,8 +539,8 @@ class GPIBInterface(_GPIBCommon, Session):
         """
         try:
             return self.controller.command(command_bytes), StatusCode.success
-        except gpib.GpibError:
-            return 0, convert_gpib_status(self.interface.ibsta())
+        except gpib.GpibError as e:
+            return convert_gpib_error(e, self.interface.ibsta()"gpib command")
 
     def gpib_send_ifc(self):
         """Pulse the interface clear line (IFC) for at least 100 microseconds.

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -539,7 +539,7 @@ class GPIBInterface(_GPIBCommon, Session):
         try:
             return self.controller.command(command_bytes), StatusCode.success
         except gpib.GpibError as e:
-            return convert_gpib_error(e, self.interface.ibsta()"gpib command")
+            return convert_gpib_error(e, self.interface.ibsta(), 'gpib command')
 
     def gpib_send_ifc(self):
         """Pulse the interface clear line (IFC) for at least 100 microseconds.


### PR DESCRIPTION
Supports up to 16 boards as per linux-gpib.

Add functionality to never perform a `listener()` on the controller address. Previously it would not yield  the address value but still  call `listener()`. This causes some gpib interfaces to lock up with a bus error until an IFC is issued. May be related to whether we call MTA of the controller as part of `ibln()` or not but some boards need that. 

Note the issue with MTA seems to be specific to linux-gpib. Testing with NI488.2 will be performed to make sure nothing breaks.





