### PR TITLE
usb: fix after_parsing logic

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,7 +19,7 @@ PyVISA-py Changelog
   communication with the instrument after a timeout occurs. PR #179
 - fix custom timeout for USB instruments. PR #179
 - fix triggering for all protocols. PR #180
-- add support for "quirky" devices made by Rigol. PR #186
+- add support for "quirky" devices made by Rigol. PR #186 PR #207
 
 0.3.1 (2018-09-12)
 ------------------

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -128,11 +128,13 @@ class BulkInMessage(namedtuple('BulkInMessage', 'msgid btag btaginverse '
 
     @classmethod
     def from_quirky(cls, data):
-        """Constructs a correct response for quirky devices"""
+        """Constructs a correct response for quirky devices.
+
+        """
         msgid, btag, btaginverse = struct.unpack_from('BBBx', data)
         data = data.rstrip(b'\x00')
         # check whether it contains a ';' and if throw away the first 12 bytes
-        if ';' in str(data):
+        if b';' in data:
             transfer_size, transfer_attributes = struct.unpack_from('<LBxxx', data, 4)
             data = data[12:]
         else:


### PR DESCRIPTION
We need to set the timeout to get the proper values but the other attributes should only be added to attrs. Also reduce code duplication.