### PR TITLE
Add support for flush operation (viFlush)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ PyVISA-py Changelog
 - fix custom timeout for USB instruments. PR #179
 - fix triggering for all protocols. PR #180
 - add support for "quirky" devices made by Rigol. PR #186 PR #207
+- add support for Visa flush operation. PR #208
 - fix reading large amounts of data from some instruments when using VXI-11. PR #209
 
 0.3.1 (2018-09-12)

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -211,7 +211,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         return sess.clear()
 
     def flush(self, session, mask):
-        """ Flushes device buffers.
+        """Flushes device buffers.
 
         Corresponds to viFlush function of the VISA library. See:
         https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html?highlight=flush#pyvisa.highlevel.VisaLibraryBase.flush

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -210,6 +210,24 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             return constants.StatusCode.error_invalid_object
         return sess.clear()
 
+    def flush(self, session, mask):
+        """ Flushes device buffers.
+
+        Corresponds to viFlush function of the VISA library. See:
+        https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html?highlight=flush#pyvisa.highlevel.VisaLibraryBase.flush
+        for valid values of mask.
+
+        :param session: Unique logical identifier to a session.
+        :param mask: which buffers to clear.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return constants.StatusCode.error_invalid_object
+        return sess.flush(mask)
+
     def gpib_command(self, session, command_byte):
         """Write GPIB command byte on the bus.
 

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -163,6 +163,21 @@ class SerialSession(Session):
         except serial.SerialTimeoutException:
             return 0, StatusCode.error_timeout
 
+    def flush(self, mask):
+        if (mask & constants.VI_READ_BUF or
+                mask & constants.VI_READ_BUF_DISCARD or
+                mask & constants.VI_IO_IN_BUF or
+                mask & constants.VI_IO_IN_BUF_DISCARD):
+            self.interface.reset_input_buffer()
+        if (mask & constants.VI_WRITE_BUF or
+                mask & constants.VI_IO_OUT_BUF):
+            self.interface.flush()
+        if (mask & constants.VI_WRITE_BUF_DISCARD or
+                mask & constants.VI_IO_OUT_BUF_DISCARD):
+            self.interface.reset_output_buffer()
+
+        return StatusCode.success
+
     def _get_attribute(self, attribute):
         """Get the value for a given VISA attribute for this session.
 

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -164,6 +164,16 @@ class SerialSession(Session):
             return 0, StatusCode.error_timeout
 
     def flush(self, mask):
+        """Flushes device buffers.
+
+        Corresponds to viFlush function of the VISA library. See:
+        https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html?highlight=flush#pyvisa.highlevel.VisaLibraryBase.flush
+        for valid values of mask.
+
+        :param mask: which buffers to clear.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
         if (mask & constants.VI_READ_BUF or
                 mask & constants.VI_READ_BUF_DISCARD or
                 mask & constants.VI_IO_IN_BUF or

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -298,6 +298,19 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         """
         return StatusCode.error_nonsupported_operation
 
+    def flush(self, mask):
+        """ Flushes device buffers.
+
+        Corresponds to viFlush function of the VISA library. See:
+        https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html?highlight=flush#pyvisa.highlevel.VisaLibraryBase.flush
+        for valid values of mask.
+
+        :param mask: which buffers to clear.
+        :return: return value of the library call.
+        :rtype: :class:`pyvisa.constants.StatusCode`
+        """
+        raise NotImplementedError
+
     def read_stb(self):
         """Reads a status byte of the service request.
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -299,7 +299,7 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         return StatusCode.error_nonsupported_operation
 
     def flush(self, mask):
-        """ Flushes device buffers.
+        """Flushes device buffers.
 
         Corresponds to viFlush function of the VISA library. See:
         https://pyvisa.readthedocs.io/en/latest/api/visalibrarybase.html?highlight=flush#pyvisa.highlevel.VisaLibraryBase.flush


### PR DESCRIPTION
This commit adds support for the flush operation, which is already implemented in pyvisa but not in pyvisa-py.

I've also implemented this for the serial interface, for the others, a `NotImplementedError` is thrown, which mirrors what currently occurs.

According to the spec, this method can be implemented for TCPIP and GPIB instruments as well:
http://zone.ni.com/reference/en-XX/help/370131S-01/ni-visa/viflush/