### PR TITLE
 protocols/rpc: don't read from TCP socket we already have the data

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ PyVISA-py Changelog
 - fix custom timeout for USB instruments. PR #179
 - fix triggering for all protocols. PR #180
 - add support for "quirky" devices made by Rigol. PR #186 PR #207
+- fix reading large amounts of data from some instruments when using VXI-11.
 
 0.3.1 (2018-09-12)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -20,7 +20,7 @@ PyVISA-py Changelog
 - fix custom timeout for USB instruments. PR #179
 - fix triggering for all protocols. PR #180
 - add support for "quirky" devices made by Rigol. PR #186 PR #207
-- fix reading large amounts of data from some instruments when using VXI-11.
+- fix reading large amounts of data from some instruments when using VXI-11. PR #209
 
 0.3.1 (2018-09-12)
 ------------------


### PR DESCRIPTION
When using TCP, if the instrument responds to a request with multiple
RPC fragments split across multiple TCP segments an incorrect recv
timeout may be raised.

This occurs if TCP segment 1 contains the start of fragment 1 _and_
TCP segment 2 contains the end of fragment 1 and all of fragment 2.

1. recv() reads segment 1 into 'buffer'.
2. recv() appends segment 2 to buffer which now contains fragments 1
   and 2.
3. Fragment 1 is completed and added to 'record'.
4. select() is called waiting for the header for fragment 2. This
   times out as fragment 2 is already in 'buffer' and there's no more
   data to read.

If 'buffer' already contains the required length ('exp_length') do not
try to read any more data.