### PR TITLE
adding usb_control_in functionality

### DIFF
--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -510,3 +510,30 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
     def discard_events(self, session, event_type, mechanism):
         # TODO: implement this for GPIB finalization
         pass
+
+    def usb_control_in(self, session, request_type_bitmap_field, request_id, request_value,
+                       index, length=0):
+        """Performs a USB control pipe transfer from the device.
+
+        Corresponds to viUsbControlIn function of the VISA library.
+
+        :param session: Unique logical identifier to a session.
+        :param request_type_bitmap_field: bmRequestType parameter of the setup stage of a USB control transfer.
+        :param request_id: bRequest parameter of the setup stage of a USB control transfer.
+        :param request_value: wValue parameter of the setup stage of a USB control transfer.
+        :param index: wIndex parameter of the setup stage of a USB control transfer.
+                      This is usually the index of the interface or endpoint.
+        :param length: wLength parameter of the setup stage of a USB control transfer.
+                       This value also specifies the size of the data buffer to receive the data from the
+                       optional data stage of the control transfer.
+        :return: - The data buffer that receives the data from the optional data stage of the control transfer
+                 - return value of the library call.
+        :rtype: - bytes
+                - :class:`pyvisa.constants.StatusCode`
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return StatusCode.error_invalid_object
+        
+        return sess.control_transfer(request_type_bitmap_field, request_id, request_value, index, length)

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -248,7 +248,6 @@ class USBRaw(object):
         :param data: bytes to be sent to the instrument
         :type data: bytes
         """
-
         try:
             return self.usb_send_ep.write(data)
         except usb.core.USBError as e:
@@ -431,3 +430,30 @@ class USBTMC(USBRaw):
                 eom = response.transfer_attributes & 1
 
         return bytes(received)
+
+    def control_transfer(self, request_type_bitmap_field, request_id, request_value,
+                       index, length):
+        """Performs a USB control pipe transfer from the device.
+
+        :param request_type_bitmap_field: bmRequestType parameter of the setup stage of a USB control transfer.
+        :param request_id: bRequest parameter of the setup stage of a USB control transfer.
+        :param request_value: wValue parameter of the setup stage of a USB control transfer.
+        :param index: wIndex parameter of the setup stage of a USB control transfer.
+                      This is usually the index of the interface or endpoint.
+        :param length: wLength parameter of the setup stage of a USB control transfer.
+                       This value also specifies the size of the data buffer to receive the data from the
+                       optional data stage of the control transfer.
+        :return: - The data buffer that receives the data from the optional data stage of the control transfer
+        :rtype: - bytes
+        """
+
+        self.usb_dev.ctrl_transfer(request_type_bitmap_field,
+                request_id,
+                request_value,
+                index,
+                length,
+                timeout=self.timeout)
+
+        #TODO satisfy the second half of the problem -i.e. sending buffer the optional data stage
+        # return self.read(length) does not work
+        return bytes()

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -144,6 +144,27 @@ class USBSession(Session):
 
         return count, StatusCode.success
 
+    def control_transfer(self, request_type_bitmap_field, request_id, request_value, index, length):
+        """Performs a USB control pipe transfer from the device.
+
+        :param request_type_bitmap_field: bmRequestType parameter of the setup stage of a USB control transfer.
+        :param request_id: bRequest parameter of the setup stage of a USB control transfer.
+        :param request_value: wValue parameter of the setup stage of a USB control transfer.
+        :param index: wIndex parameter of the setup stage of a USB control transfer.
+                      This is usually the index of the interface or endpoint.
+        :param length: wLength parameter of the setup stage of a USB control transfer.
+                       This value also specifies the size of the data buffer to receive the data from the
+                       optional data stage of the control transfer.
+
+        :return: - The data buffer that receives the data from the optional data stage of the control transfer
+                 - return value of the library call.
+        :rtype: - bytes
+                - :class:`pyvisa.constants.StatusCode`
+        """
+        ret_val = self.interface.control_transfer(request_type_bitmap_field, request_id, 
+                                                request_value, index, length)
+        return ret_val, StatusCode.success
+
     def close(self):
         self.interface.close()
 


### PR DESCRIPTION
As discussed here: https://github.com/pyvisa/pyvisa/issues/466 the pyvisa-py backend is missing the implementation of usb_control_in. This patch applies the modification needed to have it working. Tested and working with a bk8600.

Disclaimer: Is implemented the feature of control_transfer, but not the one of optional data stage - I miss the specifications and the knowledge to do that part (I tried with a plain self.read(length), but it's not enough).
If anyone can lead me to the right way, I can provide implementation for that part too.