### PR TITLE
address issues getting ICS 8065 ethernet-gpib gateway working

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ PyVISA-py Changelog
 0.4.0 (unreleased)
 ------------------
 
+- support device lan name in TCPIP INSTR resources PR #226
+- fix handling of VXI11 flags in device_write PR #226
+- do not enforce 4 bytes padding RFC 1014 since some instrument do not respect
+  it (Issue # 225) PR #226
 - fix not setting stop bits with serial devices PR #205
 - fix improper wait time before a timeout in the TCPIP backend PR # 173
 - add GPIB support for proprietary device drivers on Windows and Linux

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -254,7 +254,9 @@ class Client(object):
             result = unpack_func()
         else:
             result = None
-        self.unpacker.done()
+        # N.B. Some devices may pad responses beyond RFC 1014 4-byte
+        #   alignment, so skip self.unpacker.done() call here which
+        #   would raise an exception in that case.  See issue #225.
         return result
 
     def start_call(self, proc):

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -58,7 +58,6 @@ class TCPIPInstrSession(Session):
 
     def after_parsing(self):
         # TODO: board_number not handled
-        # TODO: lan_device_name not handled
         # vx11 expect all timeouts to be expressed in ms and should be integers
         try:
             self.interface = vxi11.CoreClient(self.parsed.host_address,

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -166,11 +166,7 @@ class TCPIPInstrSession(Session):
         chunk_size = 1024
 
         try:
-            if send_end:
-                flags = vxi11.OP_FLAG_TERMCHAR_SET
-            else:
-                flags = 0
-
+            flags = 0
             num = len(data)
             offset = 0
 


### PR DESCRIPTION
This fixes some issues raised in #225, while sorting out a setup involving an ICS 8065 ethernet-GPIB gateway.  One fix corrects the VXI-11 protocol implementation, and another avoids raising an exception when the 8065 violates RFC 1014 - harmlessly I think;  the glibc XDR implementation doesn't complain about it anyway.