### PR TITLE
usbtmc: enable remote control on USB488 devices

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ PyVISA-py Changelog
 ------------------
 
 - drop Python 2 support and run against PyVISA 1.11 PR #222
+- usbtmc: added support for USB488 devices. always assert REN bit if REN_CONTROL is supported.
 
 0.4.1 (2020-05-27)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,8 @@ PyVISA-py Changelog
 ------------------
 
 - drop Python 2 support and run against PyVISA 1.11 PR #222
-- usbtmc: added support for USB488 devices. always assert REN bit if REN_CONTROL is supported.
+- usbtmc: improve support for USB488 devices. PR #241
+  For instrument that support REN_CONTROL, we now always assert the REN line.
 
 0.4.1 (2020-05-27)
 ------------------


### PR DESCRIPTION
Thorlabs PM101 would not accept any commands without enabling
REN first.