### PR TITLE
fix crash on Windows when opening multiple devices

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ PyVISA-py Changelog
 - drop Python 2 support and run against PyVISA 1.11 PR #222
 - usbtmc: improve support for USB488 devices. PR #241
   For instrument that support REN_CONTROL, we now always assert the REN line.
+- fix a crash on Windows when opening multiple USBTMC devices
 
 0.4.1 (2020-05-27)
 ------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -62,6 +62,9 @@ to do it http://ask.xmodulo.com/change-usb-device-permission-linux.html.
 On Windows, you may have to uninstall the USBTMC specific driver installed by
 Windows and re-install a generic driver.
 
+Note that on Windows, devices that are already open cannot be detected and will
+not be returned by ``ResourceManager.list_resources``.
+
 Another useful reference for how to configure your system is h
 ttps://github.com/python-ivi/python-usbtmc.
 

--- a/pyvisa_py/protocols/usbutil.py
+++ b/pyvisa_py/protocols/usbutil.py
@@ -202,7 +202,11 @@ def find_devices(
             if custom_match is not None and not custom_match(dev):
                 return False
             for attr, pattern in attrs.items():
-                if not fnmatch(getattr(dev, attr).lower(), pattern.lower()):
+                try:
+                    value = getattr(dev, attr)
+                except (NotImplementedError, ValueError):
+                    return False
+                if not fnmatch(value.lower(), pattern.lower()):
                     return False
             return True
 


### PR DESCRIPTION
For some reason, PyUSB on Windows is unable to read the serial_number
attribute from a device that's already open in another pyusb instance,
and crashes with a cryptic "device has no langid" exception when it's accessed.

When a USB resource is opened, PyVISA-py tries to find the device by serial
number. If there's already another open device, its serial_number
attribute will be accessed in this search, triggering the langid
exception.

With this fix we will silently ignore a device when accessing a search
attribute on it raises an exception.