### PR TITLE
tcpip: implement viClear for TCPIP SOCKET and enable tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ steps:
     echo Install pytest and co
     pip install pytest pytest-azurepipelines pytest-cov
     echo Run pytest
-    python -X dev -m pytest --pyargs pyvisa_py --cov pyvisa_py --cov-report xml
+    python -X dev -m pytest --pyargs pyvisa_py --cov pyvisa_py --cov-report xml -v
   displayName: 'Run tests'
 
 - script: |

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -442,7 +442,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         except KeyError:
             return self.handle_return_value(session, StatusCode.error_invalid_object)
 
-    def open_default_resource_manager(self,) -> Tuple[VISARMSession, StatusCode]:
+    def open_default_resource_manager(self) -> Tuple[VISARMSession, StatusCode]:
         """This function returns a session to the Default Resource Manager resource.
 
         Corresponds to viOpenDefaultRM function of the VISA library.

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -215,8 +215,7 @@ class Unpacker(xdrlib.Unpacker):
 
 
 class Client(object):
-    """Common base class for clients.
-    """
+    """Common base class for clients."""
 
     def __init__(self, host, prog, vers, port):
         self.host = host
@@ -440,9 +439,7 @@ def _connect(sock, host, port, timeout=0):
 
 
 class RawTCPClient(Client):
-    """Client using TCP to a specific port.
-
-    """
+    """Client using TCP to a specific port."""
 
     def __init__(self, host, prog, vers, port, open_timeout=5000):
         Client.__init__(self, host, prog, vers, port)
@@ -452,9 +449,7 @@ class RawTCPClient(Client):
         self.timeout = 4.0
 
     def make_call(self, proc, args, pack_func, unpack_func):
-        """Overridden to allow for utilizing io_timeout (passed in args).
-
-        """
+        """Overridden to allow for utilizing io_timeout (passed in args)."""
         if proc == 11:
             # vxi11.DEVICE_WRITE
             self.timeout = args[1] / 1000.0
@@ -511,9 +506,7 @@ class RawTCPClient(Client):
 
 
 class RawUDPClient(Client):
-    """Client using UDP to a specific port.
-
-    """
+    """Client using UDP to a specific port."""
 
     def __init__(self, host, prog, vers, port):
         Client.__init__(self, host, prog, vers, port)
@@ -559,8 +552,7 @@ class RawUDPClient(Client):
 
 
 class RawBroadcastUDPClient(RawUDPClient):
-    """Client using UDP broadcast to a specific port.
-    """
+    """Client using UDP broadcast to a specific port."""
 
     def __init__(self, bcastaddr, prog, vers, port):
         RawUDPClient.__init__(self, bcastaddr, prog, vers, port)
@@ -749,8 +741,7 @@ class BroadcastUDPPortMapperClient(PartialPortMapperClient, RawBroadcastUDPClien
 
 
 class TCPClient(RawTCPClient):
-    """A TCP Client that find their server through the Port mapper
-    """
+    """A TCP Client that find their server through the Port mapper"""
 
     def __init__(self, host, prog, vers, open_timeout=5000):
         pmap = TCPPortMapperClient(host, open_timeout)
@@ -762,8 +753,7 @@ class TCPClient(RawTCPClient):
 
 
 class UDPClient(RawUDPClient):
-    """A UDP Client that find their server through the Port mapper
-    """
+    """A UDP Client that find their server through the Port mapper"""
 
     def __init__(self, host, prog, vers):
         pmap = UDPPortMapperClient(host)
@@ -775,8 +765,7 @@ class UDPClient(RawUDPClient):
 
 
 class BroadcastUDPClient(Client):
-    """A Broadcast UDP Client that find their server through the Port mapper
-    """
+    """A Broadcast UDP Client that find their server through the Port mapper"""
 
     def __init__(self, bcastaddr, prog, vers):
         self.pmap = BroadcastUDPPortMapperClient(bcastaddr)

--- a/pyvisa_py/protocols/usbraw.py
+++ b/pyvisa_py/protocols/usbraw.py
@@ -17,8 +17,7 @@ from .usbutil import find_devices, find_interfaces
 def find_raw_devices(
     vendor=None, product=None, serial_number=None, custom_match=None, **kwargs
 ):
-    """Find connected USB RAW devices. See usbutil.find_devices for more info.
-    """
+    """Find connected USB RAW devices. See usbutil.find_devices for more info."""
 
     def is_usbraw(dev):
         if custom_match and not custom_match(dev):

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -22,8 +22,7 @@ from .usbutil import find_devices, find_endpoint, find_interfaces, usb_find_desc
 
 
 class MsgID(enum.IntEnum):
-    """From USB-TMC table2
-    """
+    """From USB-TMC table2"""
 
     dev_dep_msg_out = 1
     request_dev_dep_msg_in = 2
@@ -68,9 +67,7 @@ UsbTmcCapabilities = namedtuple("UsbTmcCapabilities", "usb488 ren_control trigge
 def find_tmc_devices(
     vendor=None, product=None, serial_number=None, custom_match=None, **kwargs
 ):
-    """Find connected USBTMC devices. See usbutil.find_devices for more info.
-
-    """
+    """Find connected USBTMC devices. See usbutil.find_devices for more info."""
 
     def is_usbtmc(dev):
         if custom_match and not custom_match(dev):
@@ -128,9 +125,7 @@ class BulkInMessage(
 
     @classmethod
     def from_quirky(cls, data):
-        """Constructs a correct response for quirky devices.
-
-        """
+        """Constructs a correct response for quirky devices."""
         msgid, btag, btaginverse = struct.unpack_from("BBBx", data)
         data = data.rstrip(b"\x00")
         # check whether it contains a ';' and if throw away the first 12 bytes

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -819,7 +819,7 @@ class Session(metaclass=abc.ABCMeta):
                 return bytes(out), StatusCode.error_timeout
 
     def _get_timeout(self, attribute: ResourceAttribute) -> Tuple[int, StatusCode]:
-        """ Returns timeout calculated value from python way to VI_ way
+        """Returns timeout calculated value from python way to VI_ way
 
         In VISA, the timeout is expressed in milliseconds or using the
         constants VI_TMO_INFINITE or VI_TMO_IMMEDIATE.
@@ -837,7 +837,7 @@ class Session(metaclass=abc.ABCMeta):
         return ret_value, StatusCode.success
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int):
-        """ Sets timeout calculated value from python way to VI_ way
+        """Sets timeout calculated value from python way to VI_ way
 
         In VISA, the timeout is expressed in milliseconds or using the
         constants VI_TMO_INFINITE or VI_TMO_IMMEDIATE.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -297,7 +297,7 @@ class TCPIPInstrSession(Session):
         """
         # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
-            self.link, 0, self.lock_timeout, self._io_timeout,
+            self.link, 0, self.lock_timeout, self._io_timeout
         )
 
         return VXI11_ERRORS_TO_VISA[error]
@@ -388,9 +388,7 @@ class TCPIPInstrSession(Session):
         return VXI11_ERRORS_TO_VISA[error]
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
-        """ Sets timeout calculated value from python way to VI_ way
-
-        """
+        """Sets timeout calculated value from python way to VI_ way"""
         if value == constants.VI_TMO_INFINITE:
             self.timeout = None
             self._io_timeout = 2 ** 32 - 1

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -636,6 +636,21 @@ class TCPIPSocketSession(Session):
 
         return offset, StatusCode.success
 
+    def clear(self) -> StatusCode:
+        """Clears a device.
+
+        Corresponds to viClear function of the VISA library.
+
+        """
+        self._pending_buffer.clear()
+        while True:
+            r, w, x = select.select([self.interface], [], [], 0.1)
+            if not r:
+                break
+            r[0].recv(4096)
+
+        return StatusCode.success
+
     def _get_tcpip_nodelay(
         self, attribute: ResourceAttribute
     ) -> Tuple[constants.VisaBoolean, StatusCode]:

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
@@ -14,8 +14,7 @@ from pyvisa.testsuite.keysight_assisted_tests.test_resource_manager import (
 
 @require_virtual_instr
 class TestPyResourceManager(BaseTestResourceManager):
-    """
-    """
+    """"""
 
     test_list_resource = pytest.mark.xfail(
         copy_func(BaseTestResourceManager.test_list_resource)
@@ -32,7 +31,6 @@ class TestPyResourceManager(BaseTestResourceManager):
 
 @require_virtual_instr
 class TestPyResourceParsing(BaseTestResourceParsing):
-    """
-    """
+    """"""
 
     pass

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -8,9 +8,9 @@ from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPInstr as TCPIPInstrBaseTest,
 )
 
-# from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
-#     TestTCPIPSocket as TCPIPSocketBaseTest,
-# )
+from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
+    TestTCPIPSocket as TCPIPSocketBaseTest,
+)
 
 
 @require_virtual_instr
@@ -88,19 +88,18 @@ class TestTCPIPInstr(TCPIPInstrBaseTest):
     )
 
 
-# XXX requires to support clear.
-# @require_virtual_instr
-# class TestTCPIPSocket(TCPIPSocketBaseTest):
-#     """Test pyvisa-py against a TCPIP SOCKET resource.
+@require_virtual_instr
+class TestTCPIPSocket(TCPIPSocketBaseTest):
+    """Test pyvisa-py against a TCPIP SOCKET resource.
 
-#     """
+    """
 
-#     #: Type of resource being tested in this test case.
-#     #: See RESOURCE_ADDRESSES in the __init__.py file of this package for
-#     #: acceptable values
-#     RESOURCE_TYPE = "TCPIP::SOCKET"
+    #: Type of resource being tested in this test case.
+    #: See RESOURCE_ADDRESSES in the __init__.py file of this package for
+    #: acceptable values
+    RESOURCE_TYPE = "TCPIP::SOCKET"
 
-#     #: Minimal timeout value accepted by the resource. When setting the timeout
-#     #: to VI_TMO_IMMEDIATE, Visa (Keysight at least) may actually use a
-#     #: different value depending on the values supported by the resource.
-#     MINIMAL_TIMEOUT = 1
+    #: Minimal timeout value accepted by the resource. When setting the timeout
+    #: to VI_TMO_IMMEDIATE, Visa (Keysight at least) may actually use a
+    #: different value depending on the values supported by the resource.
+    MINIMAL_TIMEOUT = 1

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -12,9 +12,7 @@ from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
 
 @require_virtual_instr
 class TestTCPIPInstr(TCPIPInstrBaseTest):
-    """Test pyvisa-py against a TCPIP INSTR resource.
-
-    """
+    """Test pyvisa-py against a TCPIP INSTR resource."""
 
     #: Type of resource being tested in this test case.
     #: See RESOURCE_ADDRESSES in the __init__.py file of this package for
@@ -90,9 +88,7 @@ class TestTCPIPInstr(TCPIPInstrBaseTest):
 
 @require_virtual_instr
 class TestTCPIPSocket(TCPIPSocketBaseTest):
-    """Test pyvisa-py against a TCPIP SOCKET resource.
-
-    """
+    """Test pyvisa-py against a TCPIP SOCKET resource."""
 
     #: Type of resource being tested in this test case.
     #: See RESOURCE_ADDRESSES in the __init__.py file of this package for

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -103,3 +103,9 @@ class TestTCPIPSocket(TCPIPSocketBaseTest):
     #: to VI_TMO_IMMEDIATE, Visa (Keysight at least) may actually use a
     #: different value depending on the values supported by the resource.
     MINIMAL_TIMEOUT = 1
+
+    test_timeout = pytest.mark.xfail(copy_func(TCPIPInstrBaseTest.test_timeout))
+
+    test_attribute_handling = pytest.mark.xfail(
+        copy_func(TCPIPInstrBaseTest.test_attribute_handling)
+    )

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -6,9 +6,6 @@ import pytest
 from pyvisa.testsuite.keysight_assisted_tests import copy_func, require_virtual_instr
 from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPInstr as TCPIPInstrBaseTest,
-)
-
-from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPSocket as TCPIPSocketBaseTest,
 )
 
@@ -28,6 +25,9 @@ class TestTCPIPInstr(TCPIPInstrBaseTest):
     #: to VI_TMO_IMMEDIATE, Visa (Keysight at least) may actually use a
     #: different value depending on the values supported by the resource.
     MINIMAL_TIMEOUT = 0  # XXX should we try to have this match VISA ?
+
+    # XXX Skip test clear to see if it has some bad side effect
+    test_clear = pytest.mark.skip(copy_func(TCPIPInstrBaseTest.test_clear))
 
     test_wrapping_handler = pytest.mark.xfail(
         copy_func(TCPIPInstrBaseTest.test_wrapping_handler)
@@ -104,8 +104,10 @@ class TestTCPIPSocket(TCPIPSocketBaseTest):
     #: different value depending on the values supported by the resource.
     MINIMAL_TIMEOUT = 1
 
-    test_timeout = pytest.mark.xfail(copy_func(TCPIPInstrBaseTest.test_timeout))
+    test_timeout = pytest.mark.xfail(copy_func(TCPIPSocketBaseTest.test_timeout))
 
     test_attribute_handling = pytest.mark.xfail(
-        copy_func(TCPIPInstrBaseTest.test_attribute_handling)
+        copy_func(TCPIPSocketBaseTest.test_attribute_handling)
     )
+
+    test_stb = pytest.mark.xfail(copy_func(TCPIPSocketBaseTest.test_stb))


### PR DESCRIPTION
Currently we do not send *CLS since the newest specification does not mandate it.