### PR TITLE
allow serial writes to work again

### DIFF
--- a/pyvisa_py/serial.py
+++ b/pyvisa_py/serial.py
@@ -198,9 +198,12 @@ class SerialSession(Session):
             else:
                 raise ValueError("Unknown value for VI_ATTR_ASRL_END_OUT: %s" % end_out)
 
-            count = 0
-            for d in data:
-                count += self.interface.write(d)
+            if end_out == SerialTermination.last_bit:
+                count = 0
+                for d in data:
+                    count += self.interface.write(d)
+            else:
+                count = self.interface.write(data)
 
             if end_out == SerialTermination.termination_break:
                 logger.debug("Serial.sendBreak")


### PR DESCRIPTION
This change fixes RS-232 comms for me and addresses https://github.com/pyvisa/pyvisa-py/issues/272