### PR TITLE
gpib: send the proper byte when using command

### DIFF
--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -435,7 +435,7 @@ class _GPIBCommon(Session):
         try:
             if mode == constants.VI_GPIB_REN_DEASSERT_GTL:
                 # Send GTL command byte (cf linux-gpib documentation)
-                ifc.command(chr(1))
+                ifc.command(b"\x01")
             if mode in (
                 constants.VI_GPIB_REN_DEASSERT,
                 constants.VI_GPIB_REN_DEASSERT_GTL,
@@ -444,10 +444,10 @@ class _GPIBCommon(Session):
 
             if mode == constants.VI_GPIB_REN_ASSERT_LLO:
                 # LLO
-                ifc.command(b"0x11")
+                ifc.command(b"\x11")
             elif mode == constants.VI_GPIB_REN_ADDRESS_GTL:
                 # GTL
-                ifc.command(b"0x1")
+                ifc.command(b"\x01")
             elif mode == constants.VI_GPIB_REN_ASSERT_ADDRESS_LLO:
                 pass
             elif mode in (


### PR DESCRIPTION
- [ x Closes #275 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] Added an entry to the CHANGES file
