### PR TITLE
protocols: improve timeout handling for vxi11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 on:
   schedule:
-    - cron: '0 0 * * 2'
+    - cron: "0 0 * * 2"
   push:
     branches:
       - master
@@ -34,7 +34,7 @@ jobs:
           pip install git+https://github.com/pyvisa/pyvisa.git#egg=pyvisa
       - name: Isort
         run: |
-          isort pyvisa_y -c;
+          isort pyvisa_py -c;
       - name: Black
         run: |
           black pyvisa_py --check;

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -12,8 +12,8 @@ This file is an offspring of the Lantz project.
 import enum
 import socket
 
-from . import rpc
 from ..common import logger
+from . import rpc
 
 # fmt: off
 # VXI-11 RPC constants

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -6,6 +6,8 @@ import pytest
 from pyvisa.testsuite.keysight_assisted_tests import copy_func, require_virtual_instr
 from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPInstr as TCPIPInstrBaseTest,
+)
+from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPSocket as TCPIPSocketBaseTest,
 )
 

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -3,6 +3,7 @@
 
 """
 import pytest
+from pyvisa import errors
 from pyvisa.testsuite.keysight_assisted_tests import copy_func, require_virtual_instr
 from pyvisa.testsuite.keysight_assisted_tests.test_tcpip_resources import (
     TestTCPIPInstr as TCPIPInstrBaseTest,
@@ -86,6 +87,21 @@ class TestTCPIPInstr(TCPIPInstrBaseTest):
     test_attribute_handling = pytest.mark.xfail(
         copy_func(TCPIPInstrBaseTest.test_attribute_handling)
     )
+
+    def test_recovering_from_timeout(self):
+        """Test communication after a timeout.
+
+        This can fail if we do not handle properly the lastxid value.
+
+        """
+        with pytest.raises(errors.VisaIOError):
+            self.instr.read()
+
+        self.instr.write("RECEIVE")
+        self.instr.write("test")
+        self.instr.write("SEND")
+        with pytest.warns(Warning):
+            assert self.instr.read() == "test\n"
 
 
 @require_virtual_instr


### PR DESCRIPTION
Based on last comments in https://github.com/pyvisa/pyvisa/issues/367

- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
