### PR TITLE
fix #293 - Handle SUPPRESS_END_EN in usb.py

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.5.2 (unreleased)
+------------------
+
+- handle SUPPRESS_END_EN in usb.py to fix #293
+
 0.5.1 (30-09-2020)
 ------------------
 

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -84,7 +84,7 @@ class USBSession(Session):
             self.parsed.serial_number,
         )
 
-        for name in ("SEND_END_EN", "TERMCHAR", "TERMCHAR_EN"):
+        for name in ("SEND_END_EN", "SUPPRESS_END_EN", "TERMCHAR", "TERMCHAR_EN"):
             attribute = getattr(constants, "VI_ATTR_" + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 


### PR DESCRIPTION
Add SUPPRESS_END_EN to list of attributes handled in USBSessions

- [x] Closes #293  (insert issue number if relevant)
- [o] Executed ``black . && isort -c . && flake8`` with no errors
Passes black and flake8. `isort -c` has issue:
ERROR: pyvisa-py/docs/source/conf.py Imports are incorrectly sorted.
ERROR: pyvisa-py/pyvisa_py/__init__.py Imports are incorrectly sorted.
Not fixing this because pre-commit msg requests to limit scope of change
- [ ] The change is fully covered by automated unit tests
Unit tests are in pyvisa repo. Though none of them cover the list of attributes supported by USB.
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
I would do this but I thought updating the CHANGES file happens when a new version is released.
