### PR TITLE
tcpip: List resources to fix #165

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.5.3 (unreleased)
+------------------
+
+- List TCPIP resources to fix #165
+
 0.5.2 (04-02-2020)
 ------------------
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -63,15 +63,19 @@ class TCPIPInstrSession(Session):
     def list_resources() -> List[str]:
         pmap = rpc.BroadcastUDPPortMapperClient("255.255.255.255")
         pmap.set_timeout(1)
-        resp = pmap.get_port(
-            (vxi11.DEVICE_CORE_PROG, vxi11.DEVICE_CORE_VERS, rpc.IPPROTO_TCP, 0)
-        )
-        res = [r[1][0] for r in resp if r[0] > 0]
-        res = sorted(res, key=lambda ip: tuple(int(part) for part in ip.split(".")))
-        # TODO: Detect GPIB over TCPIP
-        res = ["TCPIP::{}::INSTR".format(host) for host in res]
 
-        return res
+        try:
+            resp = pmap.get_port(
+                (vxi11.DEVICE_CORE_PROG, vxi11.DEVICE_CORE_VERS, rpc.IPPROTO_TCP, 0)
+            )
+            res = [r[1][0] for r in resp if r[0] > 0]
+            res = sorted(res, key=lambda ip: tuple(int(part) for part in ip.split(".")))
+            # TODO: Detect GPIB over TCPIP
+            res = ["TCPIP::{}::INSTR".format(host) for host in res]
+
+            return res
+        except rpc.RPCError:
+            return []
 
     def after_parsing(self) -> None:
         # TODO: board_number not handled

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -61,8 +61,17 @@ class TCPIPInstrSession(Session):
 
     @staticmethod
     def list_resources() -> List[str]:
-        # TODO: is there a way to get this?
-        return []
+        pmap = rpc.BroadcastUDPPortMapperClient("255.255.255.255")
+        pmap.set_timeout(1)
+        resp = pmap.get_port(
+            (vxi11.DEVICE_CORE_PROG, vxi11.DEVICE_CORE_VERS, rpc.IPPROTO_TCP, 0)
+        )
+        res = [r[1][0] for r in resp if r[0] > 0]
+        res = sorted(res, key=lambda ip: tuple(int(part) for part in ip.split(".")))
+        # TODO: Detect GPIB over TCPIP
+        res = ["TCPIP::{}::INSTR".format(host) for host in res]
+
+        return res
 
     def after_parsing(self) -> None:
         # TODO: board_number not handled

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
@@ -3,7 +3,12 @@
 
 """
 import pytest
-from pyvisa.testsuite.keysight_assisted_tests import copy_func, require_virtual_instr
+from pyvisa.rname import ResourceName
+from pyvisa.testsuite.keysight_assisted_tests import (
+    RESOURCE_ADDRESSES,
+    copy_func,
+    require_virtual_instr,
+)
 from pyvisa.testsuite.keysight_assisted_tests.test_resource_manager import (
     TestResourceManager as BaseTestResourceManager,
     TestResourceParsing as BaseTestResourceParsing,
@@ -14,9 +19,17 @@ from pyvisa.testsuite.keysight_assisted_tests.test_resource_manager import (
 class TestPyResourceManager(BaseTestResourceManager):
     """"""
 
-    test_list_resource = pytest.mark.xfail(
-        copy_func(BaseTestResourceManager.test_list_resource)
-    )
+    def test_list_resource(self):
+        """Test listing the available resources.
+
+        The bot supports only TCPIP and of those resources we expect to be able
+        to list only INSTR resources not SOCKET.
+
+        """
+        # Default settings
+        resources = self.rm.list_resources()
+        for v in (v for v in RESOURCE_ADDRESSES.values() if v.endswith("INSTR")):
+            assert str(ResourceName.from_string(v)) in resources
 
     test_last_status = pytest.mark.xfail(
         copy_func(BaseTestResourceManager.test_last_status)


### PR DESCRIPTION
Got the snippet from https://github.com/python-ivi/python-vxi11/blob/master/vxi11/vxi11.py#L513

Signed-off-by: Edward Kigwana <ekigwana@gmail.com>

- [x] Closes #165
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
