### PR TITLE
Fix flow control setting issue, fix #316

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.5.3 (unreleased)
 ------------------
 - fix tcp/ip connections dropping from inside Docker containers after 5 minute idling #285
+- fix ControlFlow.none as an invalid attribute in serial.py PR #317
 
 0.5.2 (04-02-2020)
 ------------------

--- a/pyvisa_py/serial.py
+++ b/pyvisa_py/serial.py
@@ -418,7 +418,7 @@ class SerialSession(Session):
             if not isinstance(attribute_state, int):
                 return StatusCode.error_nonsupported_attribute_state
 
-            if not 0 < attribute_state < 8:
+            if not 0 <= attribute_state < 8:
                 return StatusCode.error_nonsupported_attribute_state
 
             try:


### PR DESCRIPTION
Flow control for serial device cannot be set to none as
0 or ControlFlow.none is treated as an invalid attribute.
Changed to "0 <="

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Closes # 316
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
