### PR TITLE
Add TCPIP instrument discovery

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 PyVISA-py Changelog
 ===================
 
+0.5.4 (Unreleased)
+------------------
+- Implement list_resources for TCPIP instruments
+
 0.5.3 (12-05-2022)
 ------------------
 - fix tcp/ip connections dropping from inside Docker containers after 5 minute idling #285

--- a/README.rst
+++ b/README.rst
@@ -64,11 +64,13 @@ Requirements
 - Python (tested with 3.6+)
 - PyVISA 1.11+
 
-Optionally
+Optionally:
+
 - PySerial (to interface with Serial instruments)
 - PyUSB (to interface with USB instruments)
 - linux-gpib (to interface with gpib instruments, only on linux)
 - gpib-ctypes (to interface with GPIB instruments on Windows and Linux)
+- psutil (to discover TCPIP devices across multiple interfaces)
 
 
 Installation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import datetime
 import os
 import sys
-import datetime
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import version as get_version

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,6 +23,9 @@ Pyvisa-py relies on :py:mod:`socket` module in the Python Standard Library to
 interact with the instrument which you do not need to install any extra library
 to access those resources.
 
+To discover devices on all interfaces, please install `psutil`_. Otherwise, 
+discovery will only occur on the default network interface. 
+
 
 Serial resources: ASRL INSTR
 ----------------------------
@@ -98,3 +101,4 @@ form GitHub_::
 .. _`issue tracker`: https://github.com/pyvisa/pyvisa-py/issues
 .. _`linux-gpib`: http://linux-gpib.sourceforge.net/
 .. _`gpib-ctypes`: https://pypi.org/project/gpib-ctypes/
+.. _`psutil`: https://pypi.org/project/psutil/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dynamic=["version"]
 gpib-ctypes = ["gpib-ctypes>=0.3.0"]
 serial = ["pyserial>=3.0"]
 usb = ["pyusb"]
+psutil = ["psutil"]
+
 
 [project.urls]
 homepage = "https://github.com/pyvisa/pyvisa-py"

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -629,6 +629,46 @@ class RawBroadcastUDPClient(RawUDPClient):
                 self.reply_handler(reply, fromaddr)
         return replies
 
+    def send_call(self, proc, args, pack_func):
+        if pack_func is None and args is not None:
+            raise TypeError("non-null args with null pack_func")
+        self.start_call(proc)
+        if pack_func:
+            pack_func(args)
+        call = self.packer.get_buf()
+        _sendto(self.sock, call, (self.host, self.port))
+
+    def recv_call(self, unpack_func):
+        BUFSIZE = 8192  # Max UDP buffer size (for reply)
+        replies = []
+        if unpack_func is None:
+
+            def dummy():
+                pass
+
+            unpack_func = dummy
+        while 1:
+            r, w, x = [self.sock], [], []
+            if select:
+                if self.timeout is None:
+                    r, w, x = select.select(r, w, x)
+                else:
+                    r, w, x = select.select(r, w, x, self.timeout)
+            if self.sock not in r:
+                break
+            reply, fromaddr = self.sock.recvfrom(BUFSIZE)
+            u = self.unpacker
+            u.reset(reply)
+            xid, verf = u.unpack_replyheader()
+            if xid != self.lastxid:
+                continue
+            reply = unpack_func()
+            self.unpacker.done()
+            replies.append((reply, fromaddr))
+            if self.reply_handler:
+                self.reply_handler(reply, fromaddr)
+        return replies
+
 
 # Port mapper interface
 
@@ -726,6 +766,18 @@ class PartialPortMapperClient(object):
             PortMapperVersion.get_port,
             mapping,
             self.packer.pack_mapping,
+            self.unpacker.unpack_uint,
+        )
+
+    def send_port(self, mapping):
+        return self.send_call(
+            PortMapperVersion.get_port,
+            mapping,
+            self.packer.pack_mapping,
+        )
+
+    def recv_port(self, mapping):
+        return self.recv_call(
             self.unpacker.unpack_uint,
         )
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional, Tuple
 
 # Let psutil be optional dependency
 try:
-    import psutil
+    import psutil  # type: ignore
 except ImportError:
     psutil = None
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -6,17 +6,17 @@
 :license: MIT, see LICENSE for more details.
 
 """
+import ipaddress
 import random
 import select
 import socket
-import ipaddress
 import time
 from typing import Any, List, Optional, Tuple
 
 # Let psutil be optional dependency
 try:
     import psutil
-except:
+except ImportError:
     psutil = None
 
 from pyvisa import attributes, constants, errors, rname

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -82,8 +82,7 @@ class TCPIPInstrSession(Session):
                         network = ipaddress.IPv4Network(addr + "/" + mask, strict=False)
                         broadcast_addr.append(str(network.broadcast_address))
         else:
-            msg = "To discover devices on all interfaces, please install psutil"
-            Session.register_unavailable(constants.InterfaceType.tcpip, "INSTR", msg)
+            # If psutil unavailable fallback to default interface
             broadcast_addr.append("255.255.255.255")
 
         try:

--- a/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
+++ b/pyvisa_py/testsuite/keysight_assisted_tests/test_resource_manager.py
@@ -3,7 +3,12 @@
 
 """
 import pytest
-from pyvisa.testsuite.keysight_assisted_tests import copy_func, require_virtual_instr
+from pyvisa.rname import ResourceName
+from pyvisa.testsuite.keysight_assisted_tests import (
+    RESOURCE_ADDRESSES,
+    copy_func,
+    require_virtual_instr,
+)
 from pyvisa.testsuite.keysight_assisted_tests.test_resource_manager import (
     TestResourceManager as BaseTestResourceManager,
     TestResourceParsing as BaseTestResourceParsing,
@@ -14,9 +19,15 @@ from pyvisa.testsuite.keysight_assisted_tests.test_resource_manager import (
 class TestPyResourceManager(BaseTestResourceManager):
     """ """
 
-    test_list_resource = pytest.mark.xfail(
-        copy_func(BaseTestResourceManager.test_list_resource)
-    )
+    def test_list_resource(self):
+        """Test listing the available resources.
+        The bot supports only TCPIP and of those resources we expect to be able
+        to list only INSTR resources not SOCKET.
+        """
+        # Default settings
+        resources = self.rm.list_resources()
+        for v in (v for v in RESOURCE_ADDRESSES.values() if v.endswith("INSTR")):
+            assert str(ResourceName.from_string(v)) in resources
 
     test_last_status = pytest.mark.xfail(
         copy_func(BaseTestResourceManager.test_last_status)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

Continues the work done in #297 by broadcasting on all interfaces. Tweaks the RPC library to add methods for only sending and only receiving broadcasts, so that the timeout period can be shared across all interfaces. 

Adds optional dependency `psutil`, which is needed to discover instruments on all interfaces. Otherwise, the only instruments on the default interface will be discovered. 

- [x] Closes #165, fixes #297
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
