### PR TITLE
tcpip: use max_recv_size as it is supposed to be used

### DIFF
--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -543,16 +543,13 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
-        send_end, _ = self.get_attribute(ResourceAttribute.send_end_enabled)
-        chunk_size = 1024
-
         try:
             flags = 0
             num = len(data)
             offset = 0
 
             while num > 0:
-                if num <= chunk_size:
+                if num <= self.max_recv_size:
                     flags |= vxi11.OP_FLAG_END
 
                 block = data[offset : offset + self.max_recv_size]


### PR DESCRIPTION
Per the VXI-11 specification the max_recv_size as provided by the server upon connection is the size of its receive buffer so we use it rather than the hardcoded minimal value of 1024.

