### PR TITLE
Adjusting license tag to use SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "PyVISA-py"
 description = "Pure Python implementation of a VISA library."
 readme = "README.rst"
 requires-python = ">=3.7"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [
   {name = "Hernan E. Grecco", email = "hernan.grecco@gmail.com"},
 ]


### PR DESCRIPTION
Hi Pyvisa folk,

My understanding is that, when possible, the license field ought to contain a descriptive identifier rather than link to the license. Typically that's when an SPDX license identifier exists. That makes it easier for automation, like the pypi website, to more cleanly describe the license.

As your license is the MIT license, here's a proposed PR to adjust it to be "MIT" rather than copying the whole license in.