### PR TITLE
add flush to TCPIP SOCKET

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,7 +22,7 @@ PyVISA-py Changelog
 0.6.1 (25-01-2023)
 ------------------
 
-- add support for the flush operation with TCPIP sockets PR #350
+- add support for the flush operation with TCPIP::SOCKET resources PR #350
 - fix listing resources when some optional dependencies are missing PR #349
 - properly list discovered TCPIP resources PR #349
 - fix pyvisa-info output for TCPIP and GPIB resources PR #349

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.7.0 (unreleased)
 ------------------
 
+- add support for the flush operation with TCPIP::SOCKET resources PR #350
 - drop support for Python 3.7 PR #362
 - fix listing of available resources PR #362
 
@@ -22,7 +23,6 @@ PyVISA-py Changelog
 0.6.1 (25-01-2023)
 ------------------
 
-- add support for the flush operation with TCPIP::SOCKET resources PR #350
 - fix listing resources when some optional dependencies are missing PR #349
 - properly list discovered TCPIP resources PR #349
 - fix pyvisa-info output for TCPIP and GPIB resources PR #349

--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ PyVISA-py Changelog
 0.6.1 (25-01-2023)
 ------------------
 
+- add support for the flush operation with TCPIP sockets PR #350
 - fix listing resources when some optional dependencies are missing PR #349
 - properly list discovered TCPIP resources PR #349
 - fix pyvisa-info output for TCPIP and GPIB resources PR #349

--- a/pyvisa_py/serial.py
+++ b/pyvisa_py/serial.py
@@ -236,12 +236,7 @@ class SerialSession(Session):
             Return value of the library call.
 
         """
-        if (
-            mask & BufferOperation.discard_read_buffer
-            or mask & BufferOperation.discard_read_buffer_no_io
-            or mask & BufferOperation.discard_receive_buffer
-            or mask & BufferOperation.discard_receive_buffer2
-        ):
+        if mask & BufferOperation.discard_read_buffer:
             self.interface.reset_input_buffer()
         if (
             mask & BufferOperation.flush_write_buffer

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -1286,7 +1286,7 @@ class TCPIPSocketSession(Session):
             or mask & BufferOperation.discard_receive_buffer
             or mask & BufferOperation.discard_receive_buffer2
         ):
-            return self.clear()
+            self.clear()
         if (
             mask & BufferOperation.flush_write_buffer
             or mask & BufferOperation.flush_transmit_buffer

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -1280,13 +1280,14 @@ class TCPIPSocketSession(Session):
         constants.StatusCode
             Return value of the library call.
         """
+        if mask & BufferOperation.discard_read_buffer:
+            self.clear()
         if (
-            mask & BufferOperation.discard_read_buffer
-            or mask & BufferOperation.discard_read_buffer_no_io
+            mask & BufferOperation.discard_read_buffer_no_io
             or mask & BufferOperation.discard_receive_buffer
             or mask & BufferOperation.discard_receive_buffer2
         ):
-            self.clear()
+            self._pending_buffer.clear()
         if (
             mask & BufferOperation.flush_write_buffer
             or mask & BufferOperation.flush_transmit_buffer

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -15,7 +15,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from pyvisa import attributes, constants, errors, rname
-from pyvisa.constants import ResourceAttribute, StatusCode
+from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
 
 from . import common
 from .protocols import hislip, rpc, vxi11
@@ -1263,6 +1263,37 @@ class TCPIPSocketSession(Session):
             if not r:
                 break
             r[0].recv(4096)
+
+        return StatusCode.success
+
+    def flush(self, mask: BufferOperation) -> StatusCode:
+        """Flush the specified buffers.
+        Corresponds to viFlush function of the VISA library.
+        Parameters
+        ----------
+        mask : constants.BufferOperation
+            Specifies the action to be taken with flushing the buffer.
+            The values can be combined using the | operator. However multiple
+            operations on a single buffer cannot be combined.
+        Returns
+        -------
+        constants.StatusCode
+            Return value of the library call.
+        """
+        if (
+            mask & BufferOperation.discard_read_buffer
+            or mask & BufferOperation.discard_read_buffer_no_io
+            or mask & BufferOperation.discard_receive_buffer
+            or mask & BufferOperation.discard_receive_buffer2
+        ):
+            return self.clear()
+        if (
+            mask & BufferOperation.flush_write_buffer
+            or mask & BufferOperation.flush_transmit_buffer
+            or mask & BufferOperation.discard_write_buffer
+            or mask & BufferOperation.discard_transmit_buffer
+        ):
+            pass
 
         return StatusCode.success
 


### PR DESCRIPTION
This PR attempts to add support for the flush operation of TCPIP Sockets. 

For Sockets the read buffer operations of `flush` seem to be equal to `clear`.
Since the writing to the sockets is blocking it seems no write buffer operations are possible/needed.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Related to #348 for TCPIP sockets
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests 
- [x] Added an entry to the CHANGES file
