### PR TITLE
Fix #351 - Avoid calling set_configuration if there is already an act…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ PyVISA-py Changelog
 ------------------
 
 - fix usb resource handling by avoiding multiple calls to set_configuration PR #352
+- formatting fixes on files using "black" PR #352
 
 0.6.1 (25-01-2023)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.6.2 (07-02-2023)
+------------------
+
+- fix usb resource handling by avoiding multiple calls to set_configuration PR #352
+
 0.6.1 (25-01-2023)
 ------------------
 

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -541,7 +541,6 @@ class Instrument:
             header = RxHeader(self._sync)
 
             if header.msg_type in ("Data", "DataEnd"):
-
                 # When receiving Data messages if the MessageID is not 0xffff ffff,
                 # then verify that the MessageID indicated in the Data message is
                 # the MessageID that the client sent to the server with the most

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -37,7 +37,6 @@ class MessagegType(enum.IntEnum):
 
 
 class AuthorizationFlavor(enum.IntEnum):
-
     null = 0
     unix = 1
     short = 2
@@ -45,13 +44,11 @@ class AuthorizationFlavor(enum.IntEnum):
 
 
 class ReplyStatus(enum.IntEnum):
-
     accepted = 0
     denied = 1
 
 
 class AcceptStatus(enum.IntEnum):
-
     #: RPC executed successfully
     success = 0
 
@@ -69,7 +66,6 @@ class AcceptStatus(enum.IntEnum):
 
 
 class RejectStatus(enum.IntEnum):
-
     #: RPC version number != 2
     rpc_mismatch = 0
 
@@ -322,7 +318,6 @@ def _sendrecord(sock, record, fragsize=None, timeout=None):
 
 
 def _recvrecord(sock, timeout, read_fun=None, min_packages=0):
-
     record = bytearray()
     buffer = bytearray()
     if not read_fun:
@@ -351,7 +346,6 @@ def _recvrecord(sock, timeout, read_fun=None, min_packages=0):
     # time, when loop shall finish
     finish_time = time.time() + timeout if timeout is not None else 0
     while True:
-
         # if more data for the current fragment is needed, use select
         # to wait for read ready, max `select_timeout` seconds
         if len(buffer) < exp_length:

--- a/pyvisa_py/protocols/usbraw.py
+++ b/pyvisa_py/protocols/usbraw.py
@@ -28,7 +28,6 @@ def find_raw_devices(
 
 
 class USBRawDevice(USBRaw):
-
     RECV_CHUNK = 1024**2
 
     find_devices = staticmethod(find_raw_devices)

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -259,7 +259,6 @@ class Session(metaclass=abc.ABCMeta):
         """
 
         class _internal(Session):
-
             #: Message detailing why no session is available.
             session_issue: str = msg
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -221,7 +221,6 @@ class TCPIPInstrHiSLIP(Session):
         return StatusCode.success
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
-
         status = super()._set_timeout(attribute, value)
         if hasattr(self.interface, "timeout"):
             self.interface.timeout = 1e-3 * value
@@ -965,7 +964,6 @@ class TCPIPInstrVicp(Session):
         return StatusCode.success
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
-
         status = super()._set_timeout(attribute, value)
         if hasattr(self.interface, "timeout"):
             self.interface.timeout = 1e-3 * value
@@ -1169,7 +1167,6 @@ class TCPIPSocketSession(Session):
         # data arrives
         finish_time = None if self.timeout is None else (time.time() + self.timeout)
         while True:
-
             # check, if we have any data received (from pending buffer or
             # further reading)
             if term_char_en and term_byte in self._pending_buffer:
@@ -1240,7 +1237,6 @@ class TCPIPSocketSession(Session):
         offset = 0
 
         while num > 0:
-
             block = data[offset : min(offset + chunk_size, sz)]
 
             try:


### PR DESCRIPTION
This PR addresses issue #351 . It will avoid calling `set_configuration` if there is
already an active interface.

- [x] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
