### PR TITLE
fix(#346): don't advertize python 3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "PyVISA-py"
 description = "Pure Python implementation of a VISA library."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
   {name = "Hernan E. Grecco", email = "hernan.grecco@gmail.com"},


### PR DESCRIPTION
Make sure package managers don't pull newer version for python 3.7

This should have happened in 0.6.0 but I don't think we can fix this. Probably pip will still try to install 0.6.0-0.6.2 for python 3.7,  but correctly these releases should be fixed with this patch.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Closes #346
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
