### PR TITLE
fix: allow custom hislip sub_address

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ PyVISA-py Changelog
 
 - drop support for Python 3.7 PR #362
 - fix listing of available resources PR #362
+- fix hislip support for custom sub_addresses PR #359
 
 0.6.3 (17-02-2023)
 ------------------

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -365,7 +365,11 @@ class Instrument:
     """
 
     def __init__(
-        self, ip_addr: str, timeout: Optional[float] = None, port: int = PORT
+        self,
+        ip_addr: str,
+        timeout: Optional[float] = None,
+        port: int = PORT,
+        sub_address: str = "hislip0",
     ) -> None:
         # init transaction:
         #     C->S: Initialize
@@ -380,7 +384,7 @@ class Instrument:
         self._sync.connect((ip_addr, port))
         self._sync.settimeout(timeout)
         self._sync.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        init = self.initialize()
+        init = self.initialize(sub_address=sub_address.encode("ascii"))
         if init.overlap != 0:
             print("**** prefer overlap = %d" % init.overlap)
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -129,12 +129,16 @@ class TCPIPInstrHiSLIP(Session):
         # TODO: board_number not handled
 
         if "," in self.parsed.lan_device_name:
-            _, port_str = self.parsed.lan_device_name.split(",")
+            sub_address, port_str = self.parsed.lan_device_name.split(",")
             port = int(port_str)
         else:
+            sub_address = self.parsed.lan_device_name
             port = 4880
         self.interface = hislip.Instrument(
-            self.parsed.host_address, port=port, timeout=self.timeout
+            self.parsed.host_address,
+            timeout=self.timeout,
+            port=port,
+            sub_address=sub_address,
         )
 
         # initialize the constant attributes


### PR DESCRIPTION
- [x] Closes #358 
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
