### PR TITLE
Support for GPIB secondary addressing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.7.1 (unreleased)
+------------------
+
+- add support for GPIB secondary addresses
+
 0.7.0 (05/05/2023)
 ------------------
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -35,6 +35,16 @@ from a pure primary address like `GPIB0::9::INSTR`.
 ``ResourceManager.list_resources()`` has become slower as a result,
 as it now needs to check 992 addresses per GPIB controller instead of just 31.
 
+For every primary address where no listener is detected, all
+secondary addresses are checked for listeners as well to find, for example,
+VXI modules controlled by an HP E1406A.
+
+For primary addresses where a listener is detected, no secondary addresses are
+checked as most devices simply ignore secondary addressing.
+
+If you have a device that reacts to the primary address and has different
+functionality on some secondary addresses, please leave a bug report.
+
 
 Can PyVISA-py be used from a VM?
 --------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -21,6 +21,21 @@ The IVI compliant VISA implementations available (`National Instruments NI-VISA`
 certain systems. We wanted to provide a compatible alternative.
 
 
+Are GBIP secondary addresses supported?
+---------------------------------------
+
+GPIB secondary addresses are supported in NI-VISA fashion, meaning that the
+secondary address is not 96 to 126 as transmitted on the bus, but 0 to 30.
+
+For expample, `GPIB0::9::1::INSTR` is the address of the first VXI module
+controlled by a GPIB VXI command module set to primary address `9`, while
+the command module itself is found at `GPIB0::9::0::INSTR`, which is distinct
+from a pure primary address like `GPIB0::9::INSTR`.
+
+``ResourceManager.list_resources()`` has become slower as a result,
+as it now needs to check 992 addresses per GPIB controller instead of just 31.
+
+
 Can PyVISA-py be used from a VM?
 --------------------------------
 

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -273,6 +273,7 @@ class _GPIBCommon(Session):
         self.interface = None
         if isinstance(self.parsed, GPIBInstr):
             pad = int(self.parsed.primary_address)
+            sad = int(self.parsed.secondary_address) + 0x60
             # Used to talk to a specific resource
             self.interface = Gpib(
                 name=minor,

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -645,7 +645,8 @@ class GPIBSession(_GPIBCommon):
     @staticmethod
     def list_resources() -> List[str]:
         return [
-            "GPIB%d::%d::INSTR" % (board, pad) if sad == 0
+            "GPIB%d::%d::INSTR" % (board, pad)
+            if sad == 0
             else "GPIB%d::%d::%d::INSTR" % (board, pad, sad - 0x60)
             for board, pad, sad in _find_listeners()
         ]

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -273,7 +273,8 @@ class _GPIBCommon(Session):
         self.interface = None
         if isinstance(self.parsed, GPIBInstr):
             pad = int(self.parsed.primary_address)
-            sad = int(self.parsed.secondary_address) + 0x60
+            if self.parsed.secondary_address is not None:
+                sad = int(self.parsed.secondary_address) + 0x60
             # Used to talk to a specific resource
             self.interface = Gpib(
                 name=minor,

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -85,18 +85,24 @@ def _find_boards() -> Iterator[Tuple[int, int]]:
             logger.debug("GPIB board %i error in _find_boards(): %s", board, repr(e))
 
 
-def _find_listeners() -> Iterator[Tuple[int, int]]:
+def _find_listeners() -> Iterator[Tuple[int, int, int]]:
     """Find GPIB listeners."""
     for board, boardpad in _find_boards():
         for i in range(31):
+            j = 0
             try:
                 if boardpad != i and gpib.listener(board, i):
-                    yield board, i
+                    yield board, i, j
+                elif boardpad != i:
+                    for j in range(96, 126):
+                        if gpib.listener(board, i, j):
+                            yield board, i, j
             except gpib.GpibError as e:
                 logger.debug(
-                    "GPIB board %i addr %i error in _find_listeners(): %s",
+                    "GPIB board %i paddr %i saddr %i error in _find_listeners(): %s",
                     board,
                     i,
+                    j,
                     repr(e),
                 )
 
@@ -638,7 +644,11 @@ class GPIBSession(_GPIBCommon):
 
     @staticmethod
     def list_resources() -> List[str]:
-        return ["GPIB%d::%d::INSTR" % (board, pad) for board, pad in _find_listeners()]
+        return [
+            "GPIB%d::%d::INSTR" % (board, pad) if sad == 0
+            else "GPIB%d::%d::%d::INSTR" % (board, pad, sad - 0x60)
+            for board, pad, sad in _find_listeners()
+        ]
 
     def clear(self) -> StatusCode:
         """Clears a device.


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->
PyVISA 1.12 made proper support for GPIB secondary addressing possible by fixing address parsing.

This pull request enables secondary addressing and extends list_resources() to detect listeners on secondary addresses with minimal effort.

Tested  with a HP E1206A command module in a VXI chassis and several VXI modules, an Anritsu MS8604A spectrum analyzer and a Prema 6000 DMM on the same bus with an Agilent 82357B bus master driven by the linux-gpib Python module.

I see no opportunity to write unit tests as linux-gpib lacks a method to add mock devices and all changes interact directly with the linux-gpib API.

- [x] Closes #307 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
