### PR TITLE
replace the call to serial.Serial with serial.serial_for_url

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.7.1 (unreleased)
 ------------------
 
+- addd URL-support to ASLR devices PR #386
 - add support for GPIB secondary addresses
 
 0.7.0 (05/05/2023)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,12 @@ steps:
       source $HOME/miniconda3/bin/activate
       echo Activate environment
       call conda activate test_
+      echo Install support packages
+      pip install pyserial
       echo Install project
       pip install git+https://github.com/pyvisa/pyvisa.git#egg=pyvisa
       pip install -e .
+      
     displayName: "Install dependencies"
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,11 +32,9 @@ steps:
       source $HOME/miniconda3/bin/activate
       echo Activate environment
       call conda activate test_
-      echo Install support packages
-      pip install pyserial
-      echo Install project
+      echo Install project amd required dependencies
       pip install git+https://github.com/pyvisa/pyvisa.git#egg=pyvisa
-      pip install -e .
+      pip install -e . poyserial
       
     displayName: "Install dependencies"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,9 @@ steps:
       source $HOME/miniconda3/bin/activate
       echo Activate environment
       call conda activate test_
-      echo Install project amd required dependencies
+      echo Install project and required dependencies
       pip install git+https://github.com/pyvisa/pyvisa.git#egg=pyvisa
-      pip install -e . poyserial
+      pip install -e .[serial]
       
     displayName: "Install dependencies"
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,16 @@ Currently Pyvisa-py support the following resources:
 - USB INSTR
 - USB RAW
 
+    Note:
+    ASRL INSTR supports also URL Handlers like 
+    
+    - loop:// --> ASLRloop://::INSTR
+    - socket:// --> ASRLsocket://::INSTR
+
+    These entries will not be listed during the device discovery `rm.list_resources()`.
+    For further details see https://pyserial.readthedocs.io/en/latest/url_handlers.html
+    
+
 You can report a problem or ask for features in the `issue tracker`_.
 Or get the code in GitHub_.
 

--- a/pyvisa_py/serial.py
+++ b/pyvisa_py/serial.py
@@ -84,10 +84,8 @@ class SerialSession(Session):
         return "via PySerial (%s)" % ver
 
     def after_parsing(self) -> None:
-        cls = serial.Serial
-
-        self.interface = cls(
-            port=("COM" if IS_WIN else "") + self.parsed.board,
+        self.interface = serial.serial_for_url(
+            ("COM" if IS_WIN else "") + self.parsed.board,
             timeout=self.timeout,
             write_timeout=self.timeout,
         )

--- a/pyvisa_py/testsuite/test_serial.py
+++ b/pyvisa_py/testsuite/test_serial.py
@@ -5,12 +5,15 @@
 :license: MIT, see LICENSE for more details.
 
 """
+import pytest
 from pyvisa import ResourceManager
 from pyvisa.testsuite import BaseTestCase
 
 
 class TestSerial(BaseTestCase):
     """Test generic property of PyVisaLibrary."""
+
+    serial = pytest.importorskip("serial", reason="PySerial not installed")
 
     def test_serial(self):
         """Test loop://"""

--- a/pyvisa_py/testsuite/test_serial.py
+++ b/pyvisa_py/testsuite/test_serial.py
@@ -31,10 +31,10 @@ class TestSerial(BaseTestCase):
             dut.write(str(msg))
             ret_val = dut.read()
             if str(msg) == ret_val:
-                expected.append("loop://")
+                expected = ["loop://"]
 
         except Exception:
-            exp_missing.append("loop://")
+            exp_missing = ["loop://"]
 
         assert sorted(available) == sorted(expected)
         assert sorted(missing) == sorted(exp_missing)

--- a/pyvisa_py/testsuite/test_serial.py
+++ b/pyvisa_py/testsuite/test_serial.py
@@ -1,0 +1,40 @@
+"""Test creating a resource manager using PyVISA-Py as a backend.
+
+
+:copyright: 2014-2023 by PyVISA-py Authors, see AUTHORS for more details.
+:license: MIT, see LICENSE for more details.
+
+"""
+from pyvisa import ResourceManager
+from pyvisa.testsuite import BaseTestCase
+
+
+class TestSerial(BaseTestCase):
+    """Test generic property of PyVisaLibrary."""
+
+    def test_serial(self):
+        """Test loop://"""
+        msg = b"Test01234567890"
+
+        available = ["loop://"]
+        expected = []
+        exp_missing = []
+        missing = {}
+
+        rm = ResourceManager("@py")
+        try:
+            dut = rm.open_resource("ASRLloop://::INSTR")
+            print("opened")
+            dut.timeout = 3000
+            dut.read_termination = "\r\n"
+            dut.write_termination = "\r\n"
+            dut.write(str(msg))
+            ret_val = dut.read()
+            if str(msg) == ret_val:
+                expected.append("loop://")
+
+        except Exception:
+            exp_missing.append("loop://")
+
+        assert sorted(available) == sorted(expected)
+        assert sorted(missing) == sorted(exp_missing)


### PR DESCRIPTION
to support loop:// and other url-types supported in pyserial (>3.0)

tested with the follwing code on python 3.11.3, pyserial 3.5:
```
import pyvisa
rm = pyvisa.ResourceManager("@py")
abc = rm.open_resource("ASRLloop://::INSTR")
abc.timeout = 3000
abc.read_termination = "\r"
abc.write_termination = "\r\n"
abc.write("Test1234567890")
print(abc.read())
```


- [ ] Closes #385
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
