### PR TITLE
Add missing sock.close() to rpc _connect()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ PyVISA-py Changelog
 ------------------
 
 - add support for GPIB secondary addresses
+- fix missing sock.close() in rpc _connect()
 
 0.7.0 (05/05/2023)
 ------------------

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -437,6 +437,7 @@ def _connect(sock, host, port, timeout=0):
 
         if time.time() >= finish_time:
             # reached timeout
+            sock.close()
             return False
 
         # `select_timout` decreased to 50% of previous or min_select_timeout


### PR DESCRIPTION
The socket was not closed if the _connect() function timed out. This lead to an unclosed socket every time a second instance of pyvisa attempted to connect to a device while the first instance of pyvisa still had an open connection.

With this fix, the second instance can back off and try again at a later time without reaching an irrecoverable state.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
