### PR TITLE
fix: Handle null term char

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ PyVISA-py Changelog
 - addd URL-support to ASLR devices PR #386
 - add support for GPIB secondary addresses
 - fix missing sock.close() in rpc _connect()
+- handle read_termination of null in tcipip
 
 0.7.0 (05/05/2023)
 ------------------

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -1146,7 +1146,7 @@ class TCPIPSocketSession(Session):
             chunk_length = self.max_recv_size
 
         term_char, _ = self.get_attribute(ResourceAttribute.termchar)
-        term_byte = common.int_to_byte(term_char) if term_char else b""
+        term_byte = common.int_to_byte(term_char) if term_char is not None else b""
         term_char_en, _ = self.get_attribute(ResourceAttribute.termchar_enabled)
         suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 


### PR DESCRIPTION
For tcpip connection, handle when termination char is \0 rather than \n or \r.

Closes #393
