### PR TITLE
(fix): fixed tcpip_keepalive for TCPIPSocketSession (#396)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ PyVISA-py Changelog
 - fix missing sock.close() in rpc _connect()
 - fix HiSLIP message tracking after read timeout PR #376
 - handle read_termination of null in tcipip PR #394
+- fix tcpip keepalive PR #396
 
 0.7.0 (05/05/2023)
 ------------------

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -134,7 +134,7 @@ class TCPIPInstrHiSLIP(Session):
         else:
             sub_address = self.parsed.lan_device_name
             port = 4880
-        self.interface: hislip.Instrument = hislip.Instrument(
+        self.interface = hislip.Instrument(
             self.parsed.host_address,
             timeout=self.timeout,
             port=port,
@@ -453,9 +453,7 @@ class TCPIPInstrVxi11(Session):
         else:
             port = None
         try:
-            self.interface: Vxi11CoreClient = Vxi11CoreClient(
-                host_address, port, self.open_timeout
-            )
+            self.interface = Vxi11CoreClient(host_address, port, self.open_timeout)
         except rpc.RPCError:
             raise errors.VisaIOError(constants.VI_ERROR_RSRC_NFOUND)
 
@@ -845,7 +843,7 @@ class TCPIPInstrVicp(Session):
         else:
             port = 1861
 
-        self.interface: pyvicp.Client = pyvicp.Client(
+        self.interface = pyvicp.Client(
             self.parsed.host_address, port, timeout=self.timeout
         )
 
@@ -1088,9 +1086,7 @@ class TCPIPSocketSession(Session):
     def _connect(self) -> StatusCode:
         timeout = self.open_timeout / 1000.0 if self.open_timeout else 10.0
         try:
-            self.interface: socket.socket = socket.socket(
-                socket.AF_INET, socket.SOCK_STREAM
-            )
+            self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.interface.setblocking(False)
             self.interface.connect_ex((self.parsed.host_address, int(self.parsed.port)))
         except Exception as e:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -134,7 +134,7 @@ class TCPIPInstrHiSLIP(Session):
         else:
             sub_address = self.parsed.lan_device_name
             port = 4880
-        self.interface = hislip.Instrument(
+        self.interface: hislip.Instrument = hislip.Instrument(
             self.parsed.host_address,
             timeout=self.timeout,
             port=port,
@@ -453,7 +453,9 @@ class TCPIPInstrVxi11(Session):
         else:
             port = None
         try:
-            self.interface = Vxi11CoreClient(host_address, port, self.open_timeout)
+            self.interface: Vxi11CoreClient = Vxi11CoreClient(
+                host_address, port, self.open_timeout
+            )
         except rpc.RPCError:
             raise errors.VisaIOError(constants.VI_ERROR_RSRC_NFOUND)
 
@@ -843,7 +845,7 @@ class TCPIPInstrVicp(Session):
         else:
             port = 1861
 
-        self.interface = pyvicp.Client(
+        self.interface: pyvicp.Client = pyvicp.Client(
             self.parsed.host_address, port, timeout=self.timeout
         )
 
@@ -1086,7 +1088,9 @@ class TCPIPSocketSession(Session):
     def _connect(self) -> StatusCode:
         timeout = self.open_timeout / 1000.0 if self.open_timeout else 10.0
         try:
-            self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.interface: socket.socket = socket.socket(
+                socket.AF_INET, socket.SOCK_STREAM
+            )
             self.interface.setblocking(False)
             self.interface.connect_ex((self.parsed.host_address, int(self.parsed.port)))
         except Exception as e:
@@ -1345,9 +1349,9 @@ class TCPIPSocketSession(Session):
             self.interface.setsockopt(
                 socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1 if attribute_state else 0
             )
-            self.interface.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-            self.interface.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)
-            self.interface.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
+            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)
+            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
             return StatusCode.success
         return StatusCode.error_nonsupported_attribute
 


### PR DESCRIPTION
Hi,

fixes #396 deprecated attribute ".sock" for TCPIPSocketSessions.

I've also included type hints for the self.interface classes, making it easier to detect such issues promptly. After implementing this change, I tested it with the same code block that initially triggered the error, and it executed as intended.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Closes #396 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
