### PR TITLE
Fix to use endpoints MaxPacketSize instead of hardcoded RECV_CHUNK size

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.7.2 (unreleased)
+------------------
+
+- fix usbtmc to use MaxPacketSize reported by endpoint
+
 0.7.1 (26/10/2023)
 ------------------
 


### PR DESCRIPTION
The issue was found to be not able to download screenshots from a RigolDS1074Z.
From this [issue](https://github.com/pyvisa/pyvisa/issues/481#issuecomment-1477334673) it was seen there is some workaround but not a fix.

As the same issue existed in the [linux-usbtmc](https://github.com/dpenkler/linux-usbtmc/issues/8) driver module it was easy to refix it here.

The main point is that those scopes have a limited MaxPacketSize which is reported by the USB device correctly and the TMC protocol is relying on using this MaxPacketSize.

