### PR TITLE
expand info/debug/warning msgs if USB device `serial_number` not readable

### DIFF
--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -8,6 +8,9 @@
 """
 
 import errno
+import logging
+import os
+import traceback
 from typing import Any, List, Tuple, Type, Union
 
 from pyvisa import attributes, constants
@@ -277,9 +280,9 @@ class USBInstrSession(USBSession):
 
             try:
                 serial = dev.serial_number
-            except (NotImplementedError, ValueError):
+            except (NotImplementedError, ValueError) as err:
                 msg = (
-                    "Found a device whose serial number cannot be read."
+                    "Found a USB INSTR device whose serial number cannot be read."
                     " The partial VISA resource name is: " + fmt
                 )
                 logger.warning(
@@ -292,6 +295,39 @@ class USBInstrSession(USBSession):
                         "usb_interface_number": intfc,
                     },
                 )
+                logging_level = logger.getEffectiveLevel()
+                if logging_level <= logging.DEBUG:
+                    if exc_strs := traceback.format_exception(err):
+                        msg = "Traceback:"
+                        logger.debug(msg)
+                        logger.debug("-" * len(msg))
+                        for exc_str in exc_strs:
+                            for line in exc_str.split("\n"):
+                                logger.debug(line)
+                        logger.debug("-" * len(msg))
+                elif logging_level <= logging.INFO:
+                    if exc_strs := traceback.format_exception_only(err):
+                        logger.info(
+                            "Error raised from underlying module (pyusb): %s",
+                            exc_strs[0].strip(),
+                        )
+
+                dev_path = f"/dev/bus/usb/{dev.bus:03d}/{dev.address:03d}"
+                if os.path.exists(dev_path) and not os.access(dev_path, os.O_RDWR):
+                    missing_perms = []
+                    if not os.access(dev_path, os.O_RDONLY):
+                        missing_perms.append("read from")
+                    if not os.access(dev_path, os.O_WRONLY):
+                        missing_perms.append("write to")
+                    missing_perms_str = " or ".join(missing_perms)
+                    logger.warning(
+                        "User does not have permission to %s %s, so the above USBTMC"
+                        " device cannot be used by pyvisa; see"
+                        " https://pyvisa.readthedocs.io/projects/pyvisa-py/en/latest/faq.html"
+                        " for more info.",
+                        missing_perms_str,
+                        dev_path,
+                    )
                 continue
 
             out.append(
@@ -336,7 +372,7 @@ class USBRawSession(USBSession):
                 serial = dev.serial_number
             except (NotImplementedError, ValueError, usb.USBError):
                 msg = (
-                    "Found a device whose serial number cannot be read."
+                    "Found a USB RAW device whose serial number cannot be read."
                     " The partial VISA resource name is: " + fmt
                 )
                 logger.warning(


### PR DESCRIPTION
if INSTR USB device,
- say that device is USB INSTR that failed in warning message
- catch exception
- debug message with traceback if logging level is DEBUG
- info message 1-line error summary if logging level is INFO
- if path f"/dev/bus/usb/{dev.bus:03d}/{dev.address:03d}" exists, check permissions on that file & refer to FAQ link (known issue on Linux)

if RAW USB device,
- say that device is USB RAW that failed in warning message

I will work on documentation fixes now, but wanted to get this in front of you for feedback in the meantime, @arr-ee (et al.).

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Working to close pyvisa issue [#758](https://github.com/pyvisa/pyvisa/issues/758)
- [x] Executed ``black . && isort -c . && flake8`` with ~no~ errors black & isort OK; flake8 doesn't like a few lines' lengths
- [ ] The change is fully covered by automated unit tests (TODO; feedback for what this could be?)
- [ ] Documented in docs/ as appropriate (TODO)
- [ ] Added an entry to the CHANGES file (TODO)
