### PR TITLE
Add read_stb method for TCPIP HiSLIP client.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyVISA-py Changelog
 ===================
 
+0.7.3 (07/06/2024)
+------------------
+
+- add read_stb method for TCPIP HiSLIP client
+
 0.7.2 (07/03/2024)
 ------------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,10 @@
 PyVISA-py Changelog
 ===================
 
-0.7.3 (07/06/2024)
+0.7.3 (unreleased)
 ------------------
 
-- add read_stb method for TCPIP HiSLIP client
+- add read_stb method for TCPIP HiSLIP client PR #429
 
 0.7.2 (07/03/2024)
 ------------------

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -13,7 +13,7 @@ import select
 import socket
 import time
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from pyvisa import attributes, constants, errors, rname
 from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
@@ -311,9 +311,9 @@ class TCPIPInstrHiSLIP(Session):
 
         """
 
-        self.interface: hislip.Instrument
+        interface = cast(hislip.Instrument, self.interface)
         # According to IVI-6.1 Rev.2 status query corresponds to viReadSTB.
-        stb = self.interface.async_status_query()
+        stb = interface.async_status_query()
         errorcode = StatusCode.success
 
         return stb, errorcode

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -297,6 +297,27 @@ class TCPIPInstrHiSLIP(Session):
 
         return StatusCode.success
 
+    def read_stb(self) -> Tuple[int, StatusCode]:
+        """Reads a status byte of the service request.
+
+        Corresponds to viReadSTB function of the VISA library.
+
+        Returns
+        -------
+        int
+            Service request status byte
+        StatusCode
+            Return value of the library call.
+
+        """
+
+        self.interface: hislip.Instrument
+        # According to IVI-6.1 Rev.2 status query corresponds to viReadSTB.
+        stb = self.interface.async_status_query()
+        errorcode = StatusCode.success
+
+        return stb, errorcode
+
     def _get_attribute(self, attribute: ResourceAttribute) -> Tuple[Any, StatusCode]:
         """Get the value for a given VISA attribute for this session.
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

This PR adds a `read_stb` method to the `TCPIPInstrHiSLIP` class, emulating the viReadSTB function.

I recently stumbled on this issue when I tried to call `resource.read_stb()` using a resource created with a HiSLIP connection.  I realized this was due to a missing method in the `TCPIPInstrHiSLIP` class, so I went ahead and implemented it. Quick trip to IVI-6.1 Rev 2.0 section 6.14 (which I found [here](https://www.ivifoundation.org/downloads/Protocol%20Specifications/IVI-6.1_HiSLIP-2.0-2020-04-23.pdf)) revealed that I can use `hislip.Instrument.async_status_query` for that.

Let me know if this is acceptable, and if there is anything I can do to make it work for you. Cheers!

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors (Checked ruff, no changes were suggested)
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
