### PR TITLE
Fixed bug in USBTMC code which caused issues when packets were longer than max usb packet size

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,10 @@ PyVISA-py Changelog
 ------------------
 
 - add read_stb method for TCPIP HiSLIP client PR #429
+- fix usbtmc implementation to respect section 3.3 of the spec PR #449
+  Read now reads from usb until a "short packet" has been read
+  (see specification), and only expects a header on the first packet received.
+- add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 
 0.7.2 (07/03/2024)
 ------------------

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -481,9 +481,9 @@ class USBTMC(USBRaw):
                 response = BulkInMessage.from_bytes(resp)
                 received.extend(response.data)
                 while len(resp) == self.usb_recv_ep.wMaxPacketSize:
-                    # USBTMC Section 3.3 specifies that the first usb packet 
-                    # must contain the header. the remaining packets do not need 
-                    # the header the message is finished when a "short packet" 
+                    # USBTMC Section 3.3 specifies that the first usb packet
+                    # must contain the header. the remaining packets do not need
+                    # the header the message is finished when a "short packet"
                     # is sent (one whose length is less than wMaxPacketSize)
                     resp = raw_read(recv_chunk + header_size + max_padding)
                     received.extend(resp)

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -481,16 +481,16 @@ class USBTMC(USBRaw):
                 response = BulkInMessage.from_bytes(resp)
                 received.extend(response.data)
                 while len(resp) == self.usb_recv_ep.wMaxPacketSize:
-                    # USBTMC Section 3.3 specifies that the first usb packet must contain the header
-                    # the remaining packets do not need the header
-                    # the message is finished when a "short packet" is sent (one whose length is less than wMaxPacketSize)
+                    # USBTMC Section 3.3 specifies that the first usb packet 
+                    # must contain the header. the remaining packets do not need 
+                    # the header the message is finished when a "short packet" 
+                    # is sent (one whose length is less than wMaxPacketSize)
                     resp = raw_read(recv_chunk + header_size + max_padding)
                     received.extend(resp)
             except (usb.core.USBError, ValueError):
                 # Abort failed Bulk-IN operation.
                 self._abort_bulk_in(self._btag)
                 raise
-
 
             # Detect EOM only when device sends all expected bytes.
             if len(response.data) >= response.transfer_size:

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -796,10 +796,9 @@ class Session(metaclass=abc.ABCMeta):
             if current:
                 out.extend(current)
                 end_indicator_received = end_indicator_checker(current)
-                if end_indicator_received:
-                    if not suppress_end_en:
-                        # RULE 6.1.1
-                        return bytes(out), StatusCode.success
+                if end_indicator_received and not suppress_end_en:
+                    # RULE 6.1.1
+                    return bytes(out), StatusCode.success
                 else:
                     if termination_char_en and (term_char in current):
                         # RULE 6.1.2

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -347,7 +347,8 @@ class USBInstrSession(USBSession):
         return self._read(
             _usb_reader,
             count,
-            lambda current: False,  # USBTMC can return partial message (i.e., before the term_char) or have trailing zeros
+            lambda current: False,  # USBTMC can return partial message (i.e.,
+            # before the term_char) or have trailing zeros
             supress_end_en,
             term_char,
             term_char_en,

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -157,11 +157,6 @@ class USBSession(Session):
 
         supress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 
-        if supress_end_en:
-            raise ValueError(
-                "VI_ATTR_SUPPRESS_END_EN == True is currently unsupported by pyvisa-py"
-            )
-
         term_char, _ = self.get_attribute(ResourceAttribute.termchar)
         term_char_en, _ = self.get_attribute(ResourceAttribute.termchar_enabled)
 
@@ -305,6 +300,7 @@ class USBInstrSession(USBSession):
                 }
             )
         return out
+
 
     def read(self, count: int) -> Tuple[bytes, StatusCode]:
         """Reads data from device or interface synchronously.

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -305,6 +305,55 @@ class USBInstrSession(USBSession):
                 }
             )
         return out
+    
+    def read(self, count: int) -> Tuple[bytes, StatusCode]:
+        """Reads data from device or interface synchronously.
+
+        Corresponds to viRead function of the VISA library.
+
+        Parameters
+        -----------
+        count : int
+            Number of bytes to be read.
+
+        Returns
+        -------
+        bytes
+            Data read from the device
+        StatusCode
+            Return value of the library call.
+
+        """
+
+        def _usb_reader():
+            """Data reader identifying usb timeout exception."""
+            try:
+                return self.interface.read(count)
+            except usb.USBError as exc:
+                if exc.errno in (errno.ETIMEDOUT, -errno.ETIMEDOUT):
+                    raise USBTimeoutException()
+                raise
+
+        supress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
+
+        if supress_end_en:
+            raise ValueError(
+                "VI_ATTR_SUPPRESS_END_EN == True is currently unsupported by pyvisa-py"
+            )
+
+        term_char, _ = self.get_attribute(ResourceAttribute.termchar)
+        term_char_en, _ = self.get_attribute(ResourceAttribute.termchar_enabled)
+
+        return self._read(
+            _usb_reader,
+            count,
+            lambda current: False,  # USBTMC can return partial message (i.e., before the term_char) or have trailing zeros
+            supress_end_en,
+            term_char,
+            term_char_en,
+            USBTimeoutException,
+        )
+
 
 
 @Session.register(constants.InterfaceType.usb, "RAW")

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -301,7 +301,6 @@ class USBInstrSession(USBSession):
             )
         return out
 
-
     def read(self, count: int) -> Tuple[bytes, StatusCode]:
         """Reads data from device or interface synchronously.
 

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -305,7 +305,7 @@ class USBInstrSession(USBSession):
                 }
             )
         return out
-    
+
     def read(self, count: int) -> Tuple[bytes, StatusCode]:
         """Reads data from device or interface synchronously.
 
@@ -354,7 +354,6 @@ class USBInstrSession(USBSession):
             term_char_en,
             USBTimeoutException,
         )
-
 
 
 @Session.register(constants.InterfaceType.usb, "RAW")


### PR DESCRIPTION
Following sec. 3.3 of "Universal Serial Bus Test and Measurement Class Specification (USBTMC)" Rev 1.0, updated the read function of USBTMC in protocols/usbtmc.py . Read now reads from usb until a "short packet" has been read (see specification), and only expects a header on the first packet received. In usb.py, added separate read function to USBInstrSession which is nearly identical to USBSessions.read, but has "lambda current: False" instead of "lambda current: True", to allow for usbtmc device to return multiple packets before a termination character and to remove trailing alignment bytes which might be sent by device.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
