### PR TITLE
readme: deduplicate requirement version specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Optionally:
 Installation
 --------------
 
-Using pip:
+Using pip::
 
     $ pip install pyvisa-py
 

--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,8 @@ controlling:
 Requirements
 ------------
 
-- Python (tested with 3.6+)
-- PyVISA 1.11+
+- Python 3
+- PyVISA
 
 Optionally:
 
@@ -74,6 +74,8 @@ Optionally:
 - zeroconf (for HiSLIP and VICP devices discovery)
 - pyvicp (to enable the Teledyne LeCroy proprietary VICP protocol)
 
+Please refer to `pyproject.toml <./pyproject.toml>`_ for the specific version
+requirements.
 
 Installation
 --------------


### PR DESCRIPTION
Specifying the dependency versions in the README file creates an extra maintenance burden not worth the effort. In fact, it has been left outdated more than once leading to misinformation. Instead, provide the rough information in the documentation and point users to the source of truth for details.

Python 3 is still listed explicitly since it won't be bumped every now and then, and provides a useful compatibility information for users. Unfortunately, PyVISA cannot be dealt with in a similar vein.

While here, also use code block syntax for `pip install` command.