### PR TITLE
Update usbtmc read to handle `transfer_size` and discard alignment bytes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,8 +6,10 @@ PyVISA-py Changelog
 
 - add read_stb method for TCPIP HiSLIP client PR #429
 - fix usbtmc implementation to respect section 3.3 of the spec PR #449
-  Read now reads from usb until a "short packet" has been read
-  (see specification), and only expects a header on the first packet received.
+  Read now reads from usb until a "short packet" or if all data (`transfer_size`) PR #465
+  has been read (see specification), and only expects a header on the first packet received.
+- fix usbtmc implementation to properly discard the alignment bytes
+  ensuring only the actual data (`transfer_size`) is retained in the message PR #465 
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 
 0.7.2 (07/03/2024)

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -484,7 +484,10 @@ class USBTMC(USBRaw):
                 received.extend(response.data)
                 transfer_size = response.transfer_size
                 transfer_attributes = response.transfer_attributes
-                while (len(resp) == self.usb_recv_ep.wMaxPacketSize or len(received) <  response.transfer_size):
+                while (
+                    len(resp) == self.usb_recv_ep.wMaxPacketSize
+                    or len(received) < response.transfer_size
+                ):
                     # USBTMC Section 3.3 specifies that the first usb packet
                     # must contain the header. the remaining packets do not need
                     # the header the message is finished when a "short packet"
@@ -502,5 +505,5 @@ class USBTMC(USBRaw):
             if len(received) >= response.transfer_size:
                 eom = transfer_attributes & 1
         # Truncate data to the specified length (discard padding)
-        # USBTMC header (12 bytes) has already truncated 
+        # USBTMC header (12 bytes) has already truncated
         return bytes(received[:transfer_size])

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -494,12 +494,12 @@ class USBTMC(USBRaw):
                     resp = raw_read(recv_chunk + header_size + max_padding)
                     received_transfer.extend(resp)
 
-                    # Detect EOM only when device sends all expected bytes.
+                # Detect EOM only when device sends all expected bytes.
                 if len(received_transfer) >= response.transfer_size:
                     eom = response.transfer_attributes & 1
                     # Truncate data to the specified length (discard padding)
                     # USBTMC header (12 bytes) has already truncated
-                    received_message = received_transfer[: response.transfer_size]
+                    received_message.extend(received_transfer[: response.transfer_size])
             except (usb.core.USBError, ValueError):
                 # Abort failed Bulk-IN operation.
                 self._abort_bulk_in(self._btag)


### PR DESCRIPTION
This PR resolves an issue where the `wMaxPacketSize` is incorrectly reported by certain drivers.
As referenced in PR #417, `wMaxPacketSize` from the USB endpoints should be used. However, on Windows with the `libusb1` driver, `wMaxPacketSize` is always reported as `1024`, even for USB 2.0 devices, where it should be `512` (`wMaxPacketSize = 0x200`). This can be listed with the `USB Device Viewer` of Windows.

To address this, the current PR enhances the changes made in PR #449 by leveraging the known `transfer_size` value from the USBTMC header, ensuring correct data handling despite incorrect `wMaxPacketSize` reporting by the driver.

Additionally, this PR fixes an issue from PR #449 where alignment bytes were not being discarded. The message should only contain the number of bytes indicated by `transfer_size`, so the USBTMC header and any alignment bytes are now properly discarded.


- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
