### PR TITLE
Support partial usbtmc reads and request the `size` amount of bytes from the device

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ PyVISA-py Changelog
   has been read (see specification), and only expects a header on the first packet received.
 - fix usbtmc implementation to properly discard the alignment bytes
   ensuring only the actual data (`transfer_size`) is retained in the message PR #465 
+- Implemented partial USBTMC message functionality that allows reading the amount of bytes 
+  specified by host.
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 
 0.7.2 (07/03/2024)

--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@ PyVISA-py Changelog
 - fix usbtmc implementation to properly discard the alignment bytes
   ensuring only the actual data (`transfer_size`) is retained in the message PR #465 
 - Implemented partial USBTMC message functionality that allows reading the amount of bytes 
-  specified by host.
+  specified by host PR #470
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 
 0.7.2 (07/03/2024)

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -476,13 +476,13 @@ class USBTMC(USBRaw):
                 # + 1 * wMaxPacketSize for message sizes that equals wMaxPacketSize == size + usbtmc_header_size.
                 # This to be able to retrieve a short package to end communication
                 # (see USB 2.0 Section 5.8.3 and USBTMC Section 3.3)
-                chunck_size = (
+                chunk_size = (
                     math.floor(
                         (size + usbtmc_header_size) / self.usb_recv_ep.wMaxPacketSize
                     )
                     + 1
                 ) * self.usb_recv_ep.wMaxPacketSize
-                resp = raw_read(chunck_size)
+                resp = raw_read(chunk_size)
 
                 response = BulkInMessage.from_bytes(resp)
                 received_transfer.extend(response.data)
@@ -507,14 +507,14 @@ class USBTMC(USBRaw):
                         # is sent (one whose length is less than wMaxPacketSize)
                         # wMaxPacketSize may be incorrectly reported by certain drivers.
                         # Therefore, continue reading until the transfer_size is reached.
-                        chunck_size = (
+                        chunk_size = (
                             math.floor(
                                 (size - len(received_transfer))
                                 / self.usb_recv_ep.wMaxPacketSize
                             )
                             + 1
                         ) * self.usb_recv_ep.wMaxPacketSize
-                        resp = raw_read(chunck_size)
+                        resp = raw_read(chunk_size)
                         received_transfer.extend(resp)
                     if len(received_transfer) >= response.transfer_size:
                         eom = response.transfer_attributes & 1


### PR DESCRIPTION
another update for reading the data back from the device. this enhances the PR #465 

changes explained below:
- `req = BulkInMessage.build_array(self._btag, size, None)` we want to request the amount of bytes from the device which user specifies. therefore the header may specify more bytes then in a single transaction `wMaxPacketSize` can be transmitted. the device may response with less bytes. 
- above is also needed when you want to support IEEE 488.2 arbitrary block reads. this normally will read 2 bytes #<number of bytes> then your read the number of bytes from the device which holds the exact amount of bytes the data package may hold. this to claim memory on the host for large data packets. see below image: 

![image](https://github.com/user-attachments/assets/f302ea43-3d03-4918-a19c-99b9b15eebf1)


-  `resp = raw_read(self.usb_recv_ep.wMaxPacketSize)` you may request `wMaxPacketSize` but the device may send less bytes than requested

- fix the indentation of the ` received_message.extend(received_transfer[: response.transfer_size])` this should always remove the alignment bytes instead of only on `EOM`

- updated the code to request `x` amount of `wMaxPacketSize` to be read instead of `wMaxPacketSize` this to improve readout speeds. 


- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
