### PR TITLE
Fixed Flow Control Setup on Serial Interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ PyVISA-py Changelog
   specified by host PR #470
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 - support open_timeout for TCPIP hislip resources PR #430
+- fix serial flow control configuration
 
 0.7.2 (07/03/2024)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -17,7 +17,7 @@ PyVISA-py Changelog
   specified by host PR #470
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 - support open_timeout for TCPIP hislip resources PR #430
-- fix serial flow control configuration
+- fix serial flow control configuration PR #483
 
 0.7.2 (07/03/2024)
 ------------------

--- a/pyvisa_py/serial.py
+++ b/pyvisa_py/serial.py
@@ -399,11 +399,15 @@ class SerialSession(Session):
                 return StatusCode.error_nonsupported_attribute_state
 
             try:
-                self.interface.xonxoff = (
+                self.interface.xonxoff = bool(
                     attribute_state & constants.VI_ASRL_FLOW_XON_XOFF
                 )
-                self.interface.rtscts = attribute_state & constants.VI_ASRL_FLOW_RTS_CTS
-                self.interface.dsrdtr = attribute_state & constants.VI_ASRL_FLOW_DTR_DSR
+                self.interface.rtscts = bool(
+                    attribute_state & constants.VI_ASRL_FLOW_RTS_CTS
+                )
+                self.interface.dsrdtr = bool(
+                    attribute_state & constants.VI_ASRL_FLOW_DTR_DSR
+                )
                 return StatusCode.success
             except Exception:
                 return StatusCode.error_nonsupported_attribute_state


### PR DESCRIPTION
Hello,
When interfacing with some serial equipment that utilized DTR and DSR for flow control, I noticed I was getting communication corruption and errors. I reimplemented this project using only pyserial and didn't have any issue which is weird because pyvisa_py uses this same library on the backend. I noticed that flow control state was not being properly set, it was passing along the internal pyvisa_py constants instead of a bool which pyserial is expecting for these settings. Once I cast the values to bool my errors were fixed.

- [ ] Closes # (insert issue number if relevant)
- [X] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
