### PR TITLE
Fix large data transfer using USBTMC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ PyVISA-py Changelog
 - add support for VI_ATTR_SUPPRESS_END_EN for USB resources PR #449
 - support open_timeout for TCPIP hislip resources PR #430
 - fix serial flow control configuration PR #483
+- Fix large data transfer using USBTMC PR #490
 
 0.7.2 (07/03/2024)
 ------------------

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -449,9 +449,9 @@ class USBTMC(USBRaw):
             self._btag = (self._btag % 255) + 1
 
             eom = end >= size
-            data = BulkOutMessage.build_array(self._btag, eom, data[begin:end])
+            datapart = BulkOutMessage.build_array(self._btag, eom, data[begin:end])
 
-            bytes_sent += raw_write(data)
+            bytes_sent += raw_write(datapart)
 
         return size
 

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -449,9 +449,9 @@ class USBTMC(USBRaw):
             self._btag = (self._btag % 255) + 1
 
             eom = end >= size
-            datapart = BulkOutMessage.build_array(self._btag, eom, data[begin:end])
+            chunk = BulkOutMessage.build_array(self._btag, eom, data[begin:end])
 
-            bytes_sent += raw_write(datapart)
+            bytes_sent += raw_write(chunk)
 
         return size
 


### PR DESCRIPTION
Transfer of large (e.g. binary) data did not work before due to an accidentally overwritten variable. This is solved in this commit by changing the variable name.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Closes #211
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
