### PR TITLE
Fix VXI-11 Default Lock Timeout (e.g. for Rigol DM3068)

### DIFF
--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -409,8 +409,8 @@ class TCPIPInstrVxi11(Session):
     #: Maximum size of a chunk of data in bytes.
     max_recv_size: int
 
-    #: Time to wait before erroring with a timeout when trying to acquire a lock
-    lock_timeout: int
+    #: Time to wait in ms before erroring with a timeout when trying to acquire a lock
+    lock_timeout: int = 10000
 
     #: Unique ID of the client used to authenticate messages.
     client_id: int
@@ -495,8 +495,6 @@ class TCPIPInstrVxi11(Session):
             )
             raise OpenError()
 
-        # vxi11 expect all timeouts to be expressed in ms and should be integers
-        self.lock_timeout = 10000
         self.client_id = random.getrandbits(31)
         self.keepalive = False
 


### PR DESCRIPTION
As explained at length in #54 and https://optics.eee.nottingham.ac.uk/vxi11/, pyvisa-py fails to communicate over Ethernet (via VXI-11) with the Rigol DM3068 digital multimeter. This is because the DM3068 expects a VXI-11 lock timeout of 0, not the default 10000ms used in pyvisa-py (which results in failure, and a 'Device Locked' response).

This commit alters where that 10000ms default is set, so it is now easily changeable by the end-user. For example:
```python
import pyvisa
rm = pyvisa.ResourceManager()
dm3068 = rm.open_resource('TCPIP::rigol-dm3068-hostname::INSTR')
# default lock_timeout is still 10000ms at this point
rm.visalib.sessions[dm3068.session].lock_timeout = 0
# can now communicate successfully with the DM3068
```