### PR TITLE
Support pyocd/libusb-package PyUSB backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,17 @@
 PyVISA-py Changelog
 ===================
 
+0.8.1 (03-09-2025)
+------------------
+
+- allow users to easily change the VXI-11 lock timeout PR #496
+- ensure listing of GPIB resources works after PR #484 PR #523
+- add support for pyocd/libusb_package PyUSB backend PR #524
+
 0.8.0 (01-04-2025)
 ------------------
 
 - add support for USB and Ethernet Prologix adapters PR #484
-- ensure listing of GPIB resources works after PR#484 PR #523
 - improve message when USB device serial number is not readable PR #423
 - ignore network interface card with no subnet mask when discovering TCPIP
   resources PR #478

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -62,12 +62,16 @@ You should not have to perform any special configuration after the install.
 USB resources: USB INSTR/RAW
 ----------------------------
 
-For **USB** resources, you need to install PyUSB_. PyUSB_ relies on USB driver
-library such as libusb 0.1, libusb 1.0, libusbx, libusb-win32 and OpenUSB
-that you should also install. Please refer to PyUSB_ documentation for more
-details.
+For **USB** resources, you need to install PyUSB_ and a suitable backend. PyUSB_
+relies on a USB driver library such as libusb 0.1, libusb 1.0, libusbx,
+libusb-win32 or OpenUSB as a suitable backend. Please refer to the PyUSB_
+documentation for more details.
 
-On Unix system, one may have to modify udev rules to allow non-root access to
+On Windows, especially if you are using a user account without administrator
+privileges, you may install `pyocd/libusb-package`_ for a convenient way to
+provide the necessary libusb 1.0 DLL as a suitable PyUSB_ backend.
+
+On Unix systems, you may have to modify udev rules to allow non-root access to
 the device you are trying to connect to. The following tutorial describes how
 to do it https://www.xmodulo.com/change-usb-device-permission-linux.html.
 
@@ -120,3 +124,4 @@ form GitHub_::
 .. _`pyvicp`: https://pypi.org/project/pyvicp/
 .. _`libusb's guide`: https://github.com/libusb/libusb/wiki/Windows#user-content-How_to_use_libusb_on_Windows
 .. _`Zadig`: https://zadig.akeo.ie/
+.. _`pyocd/libusb-package`: https://pypi.org/project/libusb-package/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@
     gpib-ctypes      = ["gpib-ctypes>=0.3.0"]
     serial           = ["pyserial>=3.0"]
     usb              = ["pyusb"]
+    usb-full         = ["pyusb", "libusb-package"]
     psutil           = ["psutil"]
     hislip-discovery = ["zeroconf"]
     vicp             = ["pyvicp", "zeroconf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ __version__ = "{version}"
   strict_optional = true
 
   [[tool.mypy.overrides]]
-    module                 = ["usb.*", "serial.*", "gpib.*", "Gpib.*", "gpib_ctypes.*", "pyvicp.*"]
+    module                 = ["usb.*", "libusb_package.*", "serial.*", "gpib.*", "Gpib.*", "gpib_ctypes.*", "pyvicp.*"]
     ignore_missing_imports = true
 
 [tool.coverage]

--- a/pyvisa_py/protocols/usbutil.py
+++ b/pyvisa_py/protocols/usbutil.py
@@ -219,7 +219,10 @@ def find_devices(
     except usb.core.NoBackendError as e1:
         try:
             import libusb_package
-            devices = libusb_package.find(find_all=True, custom_match=cm, **kwargs)
+
+            devices = libusb_package.find(
+                find_all=True, custom_match=cm, **kwargs
+            )
         except ImportError as e2:
             raise e1 from e2
 

--- a/pyvisa_py/protocols/usbutil.py
+++ b/pyvisa_py/protocols/usbutil.py
@@ -214,7 +214,16 @@ def find_devices(
     else:
         cm = custom_match
 
-    return usb.core.find(find_all=True, custom_match=cm, **kwargs)
+    try:
+        devices = usb.core.find(find_all=True, custom_match=cm, **kwargs)
+    except usb.core.NoBackendError as e1:
+        try:
+            import libusb_package
+            devices = libusb_package.find(find_all=True, custom_match=cm, **kwargs)
+        except ImportError as e2:
+            raise e1 from e2
+
+    return devices
 
 
 def find_interfaces(device, **kwargs):

--- a/pyvisa_py/protocols/usbutil.py
+++ b/pyvisa_py/protocols/usbutil.py
@@ -220,9 +220,7 @@ def find_devices(
         try:
             import libusb_package
 
-            devices = libusb_package.find(
-                find_all=True, custom_match=cm, **kwargs
-            )
+            devices = libusb_package.find(find_all=True, custom_match=cm, **kwargs)
         except ImportError as e2:
             raise e1 from e2
 

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -46,7 +46,7 @@ except Exception as e1:
             "libusb 0.1, libusb 1.0, libusbx, \n"
             "libusb-win32 or OpenUSB. If you do not have \n"
             "administrator/root privileges, you may try \n"
-            "installing the \"libusb-package\" Python \n"
+            'installing the "libusb-package" Python \n'
             "package to provide the necessary backend.\n%s\n%s" % (e2, e1)
         )
         Session.register_unavailable(constants.InterfaceType.usb, "INSTR", msg)

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -33,17 +33,21 @@ except ImportError as e:
 
 try:
     _ = usb.core.find()
-except Exception as e:
-    msg = (
-        "PyUSB does not seem to be properly installed.\n"
-        "Please refer to PyUSB documentation and \n"
-        "install a suitable backend like \n"
-        "libusb 0.1, libusb 1.0, libusbx, \n"
-        "libusb-win32 or OpenUSB.\n%s" % e
-    )
-    Session.register_unavailable(constants.InterfaceType.usb, "INSTR", msg)
-    Session.register_unavailable(constants.InterfaceType.usb, "RAW", msg)
-    raise
+except Exception as e1:
+    try:
+        import libusb_package
+        _ = libusb_package.find()
+    except Exception as e2:
+        msg = (
+            "PyUSB does not seem to be properly installed.\n"
+            "Please refer to PyUSB documentation and \n"
+            "install a suitable backend like \n"
+            "libusb 0.1, libusb 1.0, libusbx, \n"
+            "libusb-win32 or OpenUSB.\n%s\n%s" % (e2, e1)
+        )
+        Session.register_unavailable(constants.InterfaceType.usb, "INSTR", msg)
+        Session.register_unavailable(constants.InterfaceType.usb, "RAW", msg)
+        raise
 
 
 class USBTimeoutException(Exception):
@@ -78,7 +82,10 @@ class USBSession(Session):
             # noinspection PyProtectedMember
             backend = usb.core.find()._ctx.backend.__class__.__module__.split(".")[-1]
         except Exception:
-            backend = "N/A"
+            try:
+                backend = libusb_package.find()._ctx.backend.__class__.__module__.split(".")[-1]
+            except Exception:
+                backend = "N/A"
 
         return "via PyUSB (%s). Backend: %s" % (ver, backend)
 

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -41,10 +41,13 @@ except Exception as e1:
     except Exception as e2:
         msg = (
             "PyUSB does not seem to be properly installed.\n"
-            "Please refer to PyUSB documentation and \n"
+            "Please refer to the PyUSB documentation and \n"
             "install a suitable backend like \n"
             "libusb 0.1, libusb 1.0, libusbx, \n"
-            "libusb-win32 or OpenUSB.\n%s\n%s" % (e2, e1)
+            "libusb-win32 or OpenUSB. If you do not have \n"
+            "administrator/root privileges, you may try \n"
+            "installing the \"libusb-package\" Python \n"
+            "package to provide the necessary backend.\n%s\n%s" % (e2, e1)
         )
         Session.register_unavailable(constants.InterfaceType.usb, "INSTR", msg)
         Session.register_unavailable(constants.InterfaceType.usb, "RAW", msg)

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -36,6 +36,7 @@ try:
 except Exception as e1:
     try:
         import libusb_package
+
         _ = libusb_package.find()
     except Exception as e2:
         msg = (
@@ -83,7 +84,9 @@ class USBSession(Session):
             backend = usb.core.find()._ctx.backend.__class__.__module__.split(".")[-1]
         except Exception:
             try:
-                backend = libusb_package.find()._ctx.backend.__class__.__module__.split(".")[-1]
+                backend = libusb_package.find()._ctx.backend.__class__.__module__.split(
+                    "."
+                )[-1]
             except Exception:
                 backend = "N/A"
 


### PR DESCRIPTION
Attempt to use `libusb_package` if other PyUSB backends are not available. Improves robustness in environments where `libusb` can only be installed as a Python package.

Since the PyVISA-py documentation asks users to "refer to [PyUSB documentation](https://github.com/pyusb/pyusb#requirements-and-platform-support) for more details," which suggests "on Windows, [pyocd/libusb-package](https://github.com/pyocd/libusb-package/) is a convenient way to provide the necessary libusb 1.0 DLL," PyVISA-py should support this backend.

Tested working on a standard work Windows 11 user account (no admin privileges and no need to uninstall default USBTMC drivers nor mess with Zadig) for a Tektronix AFG, Tektronix MSO, and Chroma DC Electronic Load.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes #384
- [x] Executed ``black .`` with no errors
- [x] Executed ``isort -c .`` with no errors
- [ ] Executed ``flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
