### PR TITLE
Add write_termination byte for TCPIP socket session

### DIFF
--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -1276,6 +1276,12 @@ class TCPIPSocketSession(Session):
         """
         chunk_size = 4096
 
+        term_char_en, _ = self.get_attribute(ResourceAttribute.termchar_enabled)
+        if term_char_en:
+            term_char, _ = self.get_attribute(ResourceAttribute.termchar)
+            term_byte = int_to_byte(term_char) if term_char is not None else b""
+            data += term_byte
+
         num = sz = len(data)
 
         offset = 0


### PR DESCRIPTION
For some of our power supply devices it seems the write_termination is a mandatory field but it is not added for TCPIP protocol, so hereby I'm adding it.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
