### PR TITLE
Added read_stb, assert_trigger and gpib_control_run functions to usbtmc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Added read_stb and assert_trigger functions to usbtmc PR #532
+- Added read_stb, assert_trigger and gpib_control_run functions to usbtmc PR #532
 
 0.8.1 (04-09-2025)
 ------------------

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -244,6 +244,28 @@ class USBSession(Session):
             return self.interface.assert_trigger(protocol)
         return StatusCode.error_nonsupported_operation
 
+    def gpib_control_ren(self, mode: constants.RENLineOperation) -> StatusCode:
+        """Controls the state of the GPIB Remote Enable (REN) interface line.
+
+        Optionally the remote/local state of the device can also be set.
+
+        Corresponds to viGpibControlREN function of the VISA library.
+
+        Parameters
+        ----------
+        mode : constants.RENLineOperation
+            State of the REN line and optionally the device remote/local state.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        if hasattr(self.interface, "gpib_control_ren"):
+            return self.interface.gpib_control_ren(mode)
+        return StatusCode.error_nonsupported_operation
+
     def close(self):
         self.interface.close()
         return StatusCode.success


### PR DESCRIPTION
- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
