### PR TITLE
Implement viTerminate() for HiSLIP sessions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,10 @@ PyVISA-py Changelog
 ------------------
 
 - Added read_stb, assert_trigger and gpib_control_run functions to usbtmc PR #532
+- Implement viTerminate() for HiSLIP sessions using a CancellableSocket
+  (self-pipe trick on recv_into), enabling cross-thread I/O cancellation
+  without destroying the session. Also handle HiSLIP Interrupted messages
+  in the receive path. Closes #566
 
 0.8.1 (04-09-2025)
 ------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -20,8 +20,9 @@ For HiSLIP sessions (``TCPIP::host::hislip0::INSTR``), ``viTerminate()`` is
 supported.  This allows one thread to cancel a blocking read that is running
 in another thread, without destroying the session.
 
-The blocked read will return with ``VI_ERROR_ABORT``.  After the read returns,
-call ``viClear()`` to reset the HiSLIP protocol before performing further I/O::
+The blocked read will return with ``VI_ERROR_ABORT``.  The HiSLIP protocol
+state is automatically reset (via a device clear) so the session is ready for
+further I/O immediately::
 
     import pyvisa
     rm = pyvisa.ResourceManager('@py')
@@ -30,10 +31,22 @@ call ``viClear()`` to reset the HiSLIP protocol before performing further I/O::
     # From another thread, to cancel a blocked read:
     inst.visalib.terminate(inst.session, None, None)
 
-    # After the blocked read returns VI_ERROR_ABORT, reset the protocol:
-    inst.clear()
+    # The blocked read returns VI_ERROR_ABORT.
+    # The session is ready for further I/O — no manual viClear() needed.
 
 ``viTerminate()`` is not yet supported for VXI-11, USBTMC, or serial sessions.
+
+.. note::
+
+    **Portability:** This implementation goes beyond what mainstream VISA
+    libraries provide for synchronous operations.  For example, Keysight IO
+    Libraries' ``viTerminate()`` returns ``VI_SUCCESS`` but does not actually
+    cancel a blocked synchronous ``viRead()`` — the read continues until the
+    normal timeout expires.  The VISA specification defines ``viTerminate()``
+    primarily for asynchronous operations (``viReadAsync``/``viWriteAsync``),
+    and its behavior on synchronous calls is implementation-defined.  Code
+    that relies on ``viTerminate()`` cancelling a synchronous read may not
+    be portable to other VISA backends.
 
 
 Why are you developing this?

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -13,6 +13,29 @@ needed. We would like to reach feature parity. If there is something that you
 need, let us know.
 
 
+How do I cancel a pending I/O operation (viTerminate)?
+------------------------------------------------------
+
+For HiSLIP sessions (``TCPIP::host::hislip0::INSTR``), ``viTerminate()`` is
+supported.  This allows one thread to cancel a blocking read that is running
+in another thread, without destroying the session.
+
+The blocked read will return with ``VI_ERROR_ABORT``.  After the read returns,
+call ``viClear()`` to reset the HiSLIP protocol before performing further I/O::
+
+    import pyvisa
+    rm = pyvisa.ResourceManager('@py')
+    inst = rm.open_resource('TCPIP::192.168.1.100::hislip0::INSTR')
+
+    # From another thread, to cancel a blocked read:
+    inst.visalib.terminate(inst.session, None, None)
+
+    # After the blocked read returns VI_ERROR_ABORT, reset the protocol:
+    inst.clear()
+
+``viTerminate()`` is not yet supported for VXI-11, USBTMC, or serial sessions.
+
+
 Why are you developing this?
 ----------------------------
 

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -225,7 +225,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         self,
         session: VISASession,
         degree: None,
-        job_id: VISAJobID,
+        job_id: VISAJobID | None,
     ) -> StatusCode:
         """Request a VISA session to terminate normal execution of an operation.
 
@@ -237,7 +237,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             Unique logical identifier to a session.
         degree : None
             Not used in this version of the VISA specification.
-        job_id : VISAJobID
+        job_id : VISAJobID | None
             Specifies an operation identifier.  If None, aborts all calls
             on the specified session.
 

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -23,7 +23,7 @@ from typing import (
 
 from pyvisa import constants, highlevel, rname
 from pyvisa.constants import StatusCode
-from pyvisa.typing import VISAEventContext, VISARMSession, VISASession
+from pyvisa.typing import VISAEventContext, VISAJobID, VISARMSession, VISASession
 from pyvisa.util import DebugInfo, LibraryPath
 
 from .common import LOGGER
@@ -225,15 +225,11 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         self,
         session: VISASession,
         degree: None,
-        job_id,
+        job_id: VISAJobID,
     ) -> StatusCode:
         """Request a VISA session to terminate normal execution of an operation.
 
         Corresponds to viTerminate function of the VISA library.
-
-        For HiSLIP sessions, this cancels a pending read by signalling the
-        CancellableSocket's cancel pipe.  The blocked read returns with
-        StatusCode.error_abort.
 
         Parameters
         ----------
@@ -241,7 +237,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             Unique logical identifier to a session.
         degree : None
             Not used in this version of the VISA specification.
-        job_id :
+        job_id : VISAJobID
             Specifies an operation identifier.  If None, aborts all calls
             on the specified session.
 
@@ -255,7 +251,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             sess = self.sessions[session]
         except KeyError:
             return self.handle_return_value(session, StatusCode.error_invalid_object)
-        return self.handle_return_value(session, sess.terminate())
+        return self.handle_return_value(session, sess.terminate(job_id))
 
     def flush(
         self, session: VISASession, mask: constants.BufferOperation

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -221,6 +221,42 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             return self.handle_return_value(session, StatusCode.error_invalid_object)
         return self.handle_return_value(session, sess.clear())
 
+    def terminate(
+        self,
+        session: VISASession,
+        degree: None,
+        job_id,
+    ) -> StatusCode:
+        """Request a VISA session to terminate normal execution of an operation.
+
+        Corresponds to viTerminate function of the VISA library.
+
+        For HiSLIP sessions, this cancels a pending read by signalling the
+        CancellableSocket's cancel pipe.  The blocked read returns with
+        StatusCode.error_abort.
+
+        Parameters
+        ----------
+        session : VISASession
+            Unique logical identifier to a session.
+        degree : None
+            Not used in this version of the VISA specification.
+        job_id :
+            Specifies an operation identifier.  If None, aborts all calls
+            on the specified session.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return self.handle_return_value(session, StatusCode.error_invalid_object)
+        return self.handle_return_value(session, sess.terminate())
+
     def flush(
         self, session: VISASession, mask: constants.BufferOperation
     ) -> StatusCode:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -7,6 +7,7 @@ http://www.ivifoundation.org/downloads/Class%20Specifications/IVI-6.1_HiSLIP-1.1
 import select
 import socket
 import struct
+import threading
 import time
 from typing import Dict, Optional, Tuple
 
@@ -496,6 +497,7 @@ class Instrument:
         self._last_message_id: Optional[int] = None
         self._msg_type: str = ""
         self._payload_remaining: int = 0
+        self._receiving = threading.Event()
 
     # ================ #
     # MEMBER FUNCTIONS #
@@ -597,39 +599,43 @@ class Instrument:
         # note the use of receive_exact_into (which calls socket.recv_into),
         # avoiding unnecessary copies.
         #
-        recv_buffer = bytearray(max_len)
-        view = memoryview(recv_buffer)
-        bytes_recvd = 0
+        self._receiving.set()
+        try:
+            recv_buffer = bytearray(max_len)
+            view = memoryview(recv_buffer)
+            bytes_recvd = 0
 
-        while bytes_recvd < max_len:
-            if self._payload_remaining <= 0:
-                if self._msg_type == "DataEnd":
-                    # truncate to the actual number of bytes received
-                    recv_buffer = recv_buffer[:bytes_recvd]
-                    break
-                self._msg_type, self._payload_remaining = self._next_data_header()
+            while bytes_recvd < max_len:
+                if self._payload_remaining <= 0:
+                    if self._msg_type == "DataEnd":
+                        # truncate to the actual number of bytes received
+                        recv_buffer = recv_buffer[:bytes_recvd]
+                        break
+                    self._msg_type, self._payload_remaining = self._next_data_header()
 
-            request_size = min(self._payload_remaining, max_len - bytes_recvd)
-            receive_exact_into(self._sync, view[:request_size])
-            self._payload_remaining -= request_size
-            bytes_recvd += request_size
-            view = view[request_size:]
+                request_size = min(self._payload_remaining, max_len - bytes_recvd)
+                receive_exact_into(self._sync, view[:request_size])
+                self._payload_remaining -= request_size
+                bytes_recvd += request_size
+                view = view[request_size:]
 
-        if bytes_recvd > max_len:
-            raise MemoryError("scribbled past end of recv_buffer")
+            if bytes_recvd > max_len:
+                raise MemoryError("scribbled past end of recv_buffer")
 
-        # if there is no data remaining, set the RMT flag
-        if self._payload_remaining == 0 and self._msg_type == "DataEnd":
-            #
-            # From IEEE Std 488.2: Response Message Terminator.
-            #
-            # RMT is the new-line accompanied by END sent from the server
-            # to the client at the end of a response. Note that with HiSLIP
-            # this is implied by the DataEND message.
-            #
-            self._rmt = 1
+            # if there is no data remaining, set the RMT flag
+            if self._payload_remaining == 0 and self._msg_type == "DataEnd":
+                #
+                # From IEEE Std 488.2: Response Message Terminator.
+                #
+                # RMT is the new-line accompanied by END sent from the server
+                # to the client at the end of a response. Note that with HiSLIP
+                # this is implied by the DataEND message.
+                #
+                self._rmt = 1
 
-        return recv_buffer
+            return recv_buffer
+        finally:
+            self._receiving.clear()
 
     def _next_data_header(self) -> Tuple[str, int]:
         """
@@ -686,10 +692,15 @@ class Instrument:
         Thread-safe: may be called from any thread while another thread is
         blocked in receive().
 
+        If no receive() is currently in progress, this is a no-op (matching
+        the behavior of Keysight VISA's viTerminate on idle sessions).
+
         After the blocked operation returns, the caller MUST call
         complete_terminate() to reset the HiSLIP protocol state before
         performing further I/O on this session.
         """
+        if not self._receiving.is_set():
+            return
         self._sync.cancel()
 
     def complete_terminate(self) -> None:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -140,6 +140,10 @@ class CancellableSocket(socket.socket):
     """
 
     def __init__(self, sock: socket.socket) -> None:
+        # Transfer the file descriptor from the original socket.  Socket
+        # options (TCP_NODELAY, SO_KEEPALIVE, etc.) are properties of the
+        # kernel fd and are preserved across detach/re-attach.  Only
+        # Python-level state (timeout) needs explicit transfer.
         family, type_, proto = sock.family, sock.type, sock.proto
         timeout = sock.gettimeout()
         fd = sock.detach()

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -4,6 +4,7 @@ Python implementation of HiSLIP protocol.  Based on the HiSLIP spec:
 http://www.ivifoundation.org/downloads/Class%20Specifications/IVI-6.1_HiSLIP-1.1-2024-02-24.pdf
 """
 
+import select
 import socket
 import struct
 import time
@@ -114,6 +115,90 @@ HEADER_FORMAT = "!2sBBIQ"
 HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
 
 DEFAULT_MAX_MSG_SIZE = 1 << 20  # from VISA spec
+
+
+class HiSLIPInterruptedError(Exception):
+    """Raised when a pending I/O operation is cancelled via terminate().
+
+    This is the pyvisa-py equivalent of NI-VISA's VI_ERROR_ABORT.
+    """
+
+    def __init__(self, message_id: int = 0):
+        self.message_id = message_id
+        super().__init__(f"HiSLIP I/O terminated (message_id={message_id:#x})")
+
+
+class CancellableSocket:
+    """Socket wrapper that supports cross-thread cancellation via select().
+
+    Wraps a TCP socket and interposes a cancel pipe on recv_into().
+    When cancel() is called from another thread, any blocked recv_into()
+    returns immediately with HiSLIPInterruptedError.
+
+    This implements the same "self-pipe trick" that NI-VISA uses internally
+    for viTerminate() support.
+    """
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._cancel_r, self._cancel_w = socket.socketpair()
+        self._cancel_r.setblocking(False)
+        self._cancel_w.setblocking(False)
+
+    def recv_into(self, buffer, nbytes: int = 0, flags: int = 0) -> int:
+        """Cancellable recv_into using select().
+
+        Blocks until data is available on the underlying socket OR the cancel
+        pipe is signalled.  Honours the underlying socket's timeout.
+        """
+        timeout = self._sock.gettimeout()
+        readable, _, _ = select.select([self._sock, self._cancel_r], [], [], timeout)
+        if not readable:
+            raise socket.timeout("timed out")
+        if self._cancel_r in readable:
+            self._drain_cancel()
+            raise HiSLIPInterruptedError(0)
+        return self._sock.recv_into(buffer, nbytes, flags)
+
+    def cancel(self) -> None:
+        """Signal cancellation — unblocks any pending recv_into()."""
+        try:
+            self._cancel_w.send(b"\x00")
+        except BlockingIOError:
+            pass  # already signalled
+
+    def _drain_cancel(self) -> None:
+        """Drain all bytes from the cancel pipe."""
+        try:
+            while self._cancel_r.recv(1024):
+                pass
+        except BlockingIOError:
+            pass
+
+    # -- Delegate everything else to the underlying socket --
+
+    def sendall(self, data: bytes, flags: int = 0) -> None:
+        return self._sock.sendall(data, flags)
+
+    def settimeout(self, timeout) -> None:
+        return self._sock.settimeout(timeout)
+
+    def gettimeout(self):
+        return self._sock.gettimeout()
+
+    def setsockopt(self, *args) -> None:
+        return self._sock.setsockopt(*args)
+
+    def connect(self, *args) -> None:
+        return self._sock.connect(*args)
+
+    def close(self) -> None:
+        self._cancel_r.close()
+        self._cancel_w.close()
+        self._sock.close()
+
+    def fileno(self) -> int:
+        return self._sock.fileno()
 
 
 #########################################################################################
@@ -405,6 +490,11 @@ class Instrument:
         # We set the user timeout once we managed to initialize the connection.
         self._async.settimeout(timeout)
 
+        # Wrap the sync socket for viTerminate() support.
+        # The CancellableSocket interposes select() on recv_into() so that
+        # a cancel() call from another thread can unblock a pending read.
+        self._sync = CancellableSocket(self._sync)
+
         # initialize variables
         self.max_msg_size = DEFAULT_MAX_MSG_SIZE
         self.keepalive = False
@@ -572,6 +662,12 @@ class Instrument:
                 ):
                     break
 
+            if header.msg_type == "Interrupted":
+                # Server sent Interrupted in response to AsyncDeviceClear.
+                # Per IVI-6.1, the client should discard buffered data and
+                # signal the abort to the caller.
+                raise HiSLIPInterruptedError(header.message_parameter)
+
             # we're out of sync.  flush this message and continue.
             receive_flush(self._sync, header.payload_length)
 
@@ -586,6 +682,87 @@ class Instrument:
         self.device_clear_complete(feature)
         # reset messageID and resume normal opreation
         self._message_id = 0xFFFF_FF00
+
+    def terminate(self) -> None:
+        """Cancel a pending I/O operation on the synchronous channel.
+
+        This is the pyvisa-py equivalent of NI-VISA's viTerminate().
+        It writes to the cancel pipe, which causes any blocked recv_into()
+        in the CancellableSocket to return immediately with
+        HiSLIPInterruptedError (mapped to VI_ERROR_ABORT at the session layer).
+
+        Thread-safe: may be called from any thread while another thread is
+        blocked in receive().
+
+        After the blocked operation returns, the caller MUST call
+        complete_terminate() to reset the HiSLIP protocol state before
+        performing further I/O on this session.
+        """
+        self._sync.cancel()
+
+    def complete_terminate(self) -> None:
+        """Reset HiSLIP protocol state after terminate().
+
+        Must be called after terminate() and after the blocked I/O thread
+        has returned.  Performs a full HiSLIP device clear to re-sync the
+        synchronous channel:
+
+        1. Drain the cancel pipe (so it doesn't interfere with reads)
+        2. Drain any partial/garbled data from the sync socket buffer
+        3. Full HiSLIP AsyncDeviceClear → Interrupted → DeviceClearComplete
+        4. Reset message counters
+        """
+        # 1. Drain the cancel pipe
+        self._sync._drain_cancel()
+
+        # 2. Drain any bytes left in the sync socket buffer.
+        #    After terminate() interrupted a read mid-stream, there may be
+        #    partial HiSLIP message data in the buffer.
+        raw = self._sync._sock
+        raw.setblocking(False)
+        try:
+            while True:
+                try:
+                    chunk = raw.recv(65536)
+                    if not chunk:
+                        break
+                except BlockingIOError:
+                    break
+        finally:
+            raw.setblocking(True)
+            raw.settimeout(self._timeout)
+
+        # 3. Full device clear: AsyncDeviceClear → Interrupted →
+        #    DeviceClearComplete → DeviceClearAcknowledge
+        feature = self.async_device_clear()
+
+        # Read from the sync channel until we get the Interrupted message.
+        # The server sends Interrupted after acknowledging AsyncDeviceClear.
+        saved_timeout = raw.gettimeout()
+        raw.settimeout(2.0)
+        try:
+            while True:
+                header = RxHeader(raw)
+                if header.msg_type == "Interrupted":
+                    break
+                # Discard payload of any other messages
+                if header.payload_length > 0:
+                    receive_flush(raw, header.payload_length)
+        except socket.timeout:
+            # Server didn't send Interrupted — proceed anyway.
+            # DeviceClearComplete will still reset the protocol.
+            pass
+        finally:
+            raw.settimeout(saved_timeout)
+
+        self.device_clear_complete(feature)
+
+        # 4. Reset all protocol state
+        self._message_id = 0xFFFF_FF00
+        self._last_message_id = None
+        self._rmt = 0
+        self._payload_remaining = 0
+        self._msg_type = ""
 
     def initialize(
         self,

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -128,37 +128,44 @@ class HiSLIPInterruptedError(Exception):
         super().__init__(f"HiSLIP I/O terminated (message_id={message_id:#x})")
 
 
-class CancellableSocket:
-    """Socket wrapper that supports cross-thread cancellation via select().
+class CancellableSocket(socket.socket):
+    """Socket subclass that supports cross-thread cancellation via select().
 
-    Wraps a TCP socket and interposes a cancel pipe on recv_into().
-    When cancel() is called from another thread, any blocked recv_into()
-    returns immediately with HiSLIPInterruptedError.
+    Takes ownership of an existing socket's file descriptor and interposes
+    a cancel pipe on recv_into().  When cancel() is called from another
+    thread, any blocked recv_into() returns immediately with
+    HiSLIPInterruptedError.
 
-    This implements the same "self-pipe trick" that NI-VISA uses internally
-    for viTerminate() support.
+    This implements the "self-pipe trick" for viTerminate() support.
     """
 
     def __init__(self, sock: socket.socket) -> None:
-        self._sock = sock
+        family, type_, proto = sock.family, sock.type, sock.proto
+        timeout = sock.gettimeout()
+        fd = sock.detach()
+        super().__init__(family=family, type=type_, proto=proto, fileno=fd)
+        self.settimeout(timeout)
         self._cancel_r, self._cancel_w = socket.socketpair()
         self._cancel_r.setblocking(False)
         self._cancel_w.setblocking(False)
+        self._cancel_enabled = True
 
     def recv_into(self, buffer, nbytes: int = 0, flags: int = 0) -> int:
         """Cancellable recv_into using select().
 
         Blocks until data is available on the underlying socket OR the cancel
-        pipe is signalled.  Honours the underlying socket's timeout.
+        pipe is signalled.  Honours the socket's timeout.
         """
-        timeout = self._sock.gettimeout()
-        readable, _, _ = select.select([self._sock, self._cancel_r], [], [], timeout)
+        if not self._cancel_enabled:
+            return super().recv_into(buffer, nbytes, flags)
+        timeout = self.gettimeout()
+        readable, _, _ = select.select([self.fileno(), self._cancel_r], [], [], timeout)
         if not readable:
             raise socket.timeout("timed out")
         if self._cancel_r in readable:
-            self._drain_cancel()
+            self.drain_cancel()
             raise HiSLIPInterruptedError(0)
-        return self._sock.recv_into(buffer, nbytes, flags)
+        return super().recv_into(buffer, nbytes, flags)
 
     def cancel(self) -> None:
         """Signal cancellation — unblocks any pending recv_into()."""
@@ -167,7 +174,7 @@ class CancellableSocket:
         except BlockingIOError:
             pass  # already signalled
 
-    def _drain_cancel(self) -> None:
+    def drain_cancel(self) -> None:
         """Drain all bytes from the cancel pipe."""
         try:
             while self._cancel_r.recv(1024):
@@ -175,30 +182,10 @@ class CancellableSocket:
         except BlockingIOError:
             pass
 
-    # -- Delegate everything else to the underlying socket --
-
-    def sendall(self, data: bytes, flags: int = 0) -> None:
-        return self._sock.sendall(data, flags)
-
-    def settimeout(self, timeout) -> None:
-        return self._sock.settimeout(timeout)
-
-    def gettimeout(self):
-        return self._sock.gettimeout()
-
-    def setsockopt(self, *args) -> None:
-        return self._sock.setsockopt(*args)
-
-    def connect(self, *args) -> None:
-        return self._sock.connect(*args)
-
     def close(self) -> None:
         self._cancel_r.close()
         self._cancel_w.close()
-        self._sock.close()
-
-    def fileno(self) -> int:
-        return self._sock.fileno()
+        super().close()
 
 
 #########################################################################################
@@ -468,13 +455,19 @@ class Instrument:
         timeout = timeout or 5.0
 
         # open the synchronous socket and send an initialize packet
-        self._sync = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw_sync = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # The VISA spec does not allow to tune the socket timeout when opening
         # a connection. ``open_timeout`` only applies to attempt to acquire a
         # lock.
-        self._sync.settimeout(5.0)
-        self._sync.connect((ip_addr, port))
-        self._sync.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        raw_sync.settimeout(5.0)
+        raw_sync.connect((ip_addr, port))
+        raw_sync.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        # Wrap with CancellableSocket for viTerminate() support.
+        # The wrapper interposes select() on recv_into() so that a cancel()
+        # call from another thread can unblock a pending read.
+        self._sync: CancellableSocket = CancellableSocket(raw_sync)
+
         init = self.initialize(sub_address=sub_address.encode("ascii"))
         if init.overlap != 0:
             print("**** prefer overlap = %d" % init.overlap)
@@ -489,11 +482,6 @@ class Instrument:
         self._async_init = self.async_initialize(session_id=init.session_id)
         # We set the user timeout once we managed to initialize the connection.
         self._async.settimeout(timeout)
-
-        # Wrap the sync socket for viTerminate() support.
-        # The CancellableSocket interposes select() on recv_into() so that
-        # a cancel() call from another thread can unblock a pending read.
-        self._sync = CancellableSocket(self._sync)
 
         # initialize variables
         self.max_msg_size = DEFAULT_MAX_MSG_SIZE
@@ -686,10 +674,10 @@ class Instrument:
     def terminate(self) -> None:
         """Cancel a pending I/O operation on the synchronous channel.
 
-        This is the pyvisa-py equivalent of NI-VISA's viTerminate().
-        It writes to the cancel pipe, which causes any blocked recv_into()
-        in the CancellableSocket to return immediately with
-        HiSLIPInterruptedError (mapped to VI_ERROR_ABORT at the session layer).
+        Implements viTerminate() for HiSLIP sessions.  Writes to the cancel
+        pipe, which causes any blocked recv_into() in the CancellableSocket
+        to return immediately with HiSLIPInterruptedError (mapped to
+        VI_ERROR_ABORT at the session layer).
 
         Thread-safe: may be called from any thread while another thread is
         blocked in receive().
@@ -713,49 +701,54 @@ class Instrument:
         4. Reset message counters
         """
         # 1. Drain the cancel pipe
-        self._sync._drain_cancel()
+        self._sync.drain_cancel()
 
-        # 2. Drain any bytes left in the sync socket buffer.
-        #    After terminate() interrupted a read mid-stream, there may be
-        #    partial HiSLIP message data in the buffer.
-        raw = self._sync._sock
-        raw.setblocking(False)
+        # Disable cancellation for all cleanup I/O — we don't want the
+        # cancel pipe interfering with the device-clear handshake.
+        self._sync._cancel_enabled = False
         try:
-            while True:
-                try:
-                    chunk = raw.recv(65536)
-                    if not chunk:
+            # 2. Drain any bytes left in the sync socket buffer.
+            #    After terminate() interrupted a read mid-stream, there may be
+            #    partial HiSLIP message data in the buffer.
+            self._sync.setblocking(False)
+            try:
+                while True:
+                    try:
+                        chunk = self._sync.recv(65536)
+                        if not chunk:
+                            break
+                    except BlockingIOError:
                         break
-                except BlockingIOError:
-                    break
+            finally:
+                self._sync.setblocking(True)
+                self._sync.settimeout(self._timeout)
+
+            # 3. Full device clear: AsyncDeviceClear → Interrupted →
+            #    DeviceClearComplete → DeviceClearAcknowledge
+            feature = self.async_device_clear()
+
+            # Read from the sync channel until we get the Interrupted message.
+            # The server sends Interrupted after acknowledging AsyncDeviceClear.
+            saved_timeout = self._sync.gettimeout()
+            self._sync.settimeout(2.0)
+            try:
+                while True:
+                    header = RxHeader(self._sync)
+                    if header.msg_type == "Interrupted":
+                        break
+                    # Discard payload of any other messages
+                    if header.payload_length > 0:
+                        receive_flush(self._sync, header.payload_length)
+            except socket.timeout:
+                # Server didn't send Interrupted — proceed anyway.
+                # DeviceClearComplete will still reset the protocol.
+                pass
+            finally:
+                self._sync.settimeout(saved_timeout)
+
+            self.device_clear_complete(feature)
         finally:
-            raw.setblocking(True)
-            raw.settimeout(self._timeout)
-
-        # 3. Full device clear: AsyncDeviceClear → Interrupted →
-        #    DeviceClearComplete → DeviceClearAcknowledge
-        feature = self.async_device_clear()
-
-        # Read from the sync channel until we get the Interrupted message.
-        # The server sends Interrupted after acknowledging AsyncDeviceClear.
-        saved_timeout = raw.gettimeout()
-        raw.settimeout(2.0)
-        try:
-            while True:
-                header = RxHeader(raw)
-                if header.msg_type == "Interrupted":
-                    break
-                # Discard payload of any other messages
-                if header.payload_length > 0:
-                    receive_flush(raw, header.payload_length)
-        except socket.timeout:
-            # Server didn't send Interrupted — proceed anyway.
-            # DeviceClearComplete will still reset the protocol.
-            pass
-        finally:
-            raw.settimeout(saved_timeout)
-
-        self.device_clear_complete(feature)
+            self._sync._cancel_enabled = True
 
         # 4. Reset all protocol state
         self._message_id = 0xFFFF_FF00

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -419,6 +419,19 @@ class Session(metaclass=abc.ABCMeta):
         """
         return StatusCode.error_nonsupported_operation
 
+    def terminate(self) -> StatusCode:
+        """Cancel a pending I/O operation.
+
+        Corresponds to viTerminate function of the VISA library.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        return StatusCode.error_nonsupported_operation
+
     def flush(self, mask: constants.BufferOperation) -> StatusCode:
         """Flush the specified buffers.
 

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -419,14 +419,14 @@ class Session(metaclass=abc.ABCMeta):
         """
         return StatusCode.error_nonsupported_operation
 
-    def terminate(self, job_id: VISAJobID = None) -> StatusCode:
+    def terminate(self, job_id: VISAJobID | None = None) -> StatusCode:
         """Cancel a pending I/O operation.
 
         Corresponds to viTerminate function of the VISA library.
 
         Parameters
         ----------
-        job_id : VISAJobID, optional
+        job_id : VISAJobID | None, optional
             Specifies an operation identifier.  If None, aborts all calls
             on this session.
 

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -24,7 +24,7 @@ from typing import (
 
 from pyvisa import attributes, constants, rname
 from pyvisa.constants import ResourceAttribute, StatusCode
-from pyvisa.typing import VISARMSession
+from pyvisa.typing import VISAJobID, VISARMSession
 
 from .common import LOGGER, int_to_byte
 
@@ -419,10 +419,16 @@ class Session(metaclass=abc.ABCMeta):
         """
         return StatusCode.error_nonsupported_operation
 
-    def terminate(self) -> StatusCode:
+    def terminate(self, job_id: VISAJobID = None) -> StatusCode:
         """Cancel a pending I/O operation.
 
         Corresponds to viTerminate function of the VISA library.
+
+        Parameters
+        ----------
+        job_id : VISAJobID, optional
+            Specifies an operation identifier.  If None, aborts all calls
+            on this session.
 
         Returns
         -------

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -273,6 +273,9 @@ class TCPIPInstrHiSLIP(Session):
                 else StatusCode.success
             )
 
+        except hislip.HiSLIPInterruptedError:
+            data, status = b"", StatusCode.error_abort
+
         except socket.timeout:
             data, status = b"", StatusCode.error_timeout
 
@@ -330,6 +333,46 @@ class TCPIPInstrHiSLIP(Session):
         errorcode = StatusCode.success
 
         return stb, errorcode
+
+    def terminate(self) -> StatusCode:
+        """Cancel a pending I/O operation on this session.
+
+        Corresponds to viTerminate function of the VISA library.
+
+        Thread-safe: may be called from any thread while another thread is
+        blocked in read().  The blocked read() will return with
+        StatusCode.error_abort.
+
+        After the blocked operation returns, the caller MUST call
+        complete_terminate() to reset the HiSLIP protocol before performing
+        further I/O.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        interface = cast(hislip.Instrument, self.interface)
+        interface.terminate()
+        return StatusCode.success
+
+    def complete_terminate(self) -> StatusCode:
+        """Reset HiSLIP protocol state after terminate().
+
+        Must be called after terminate() and after the blocked read thread
+        has exited.  Performs a full HiSLIP device clear to re-synchronize
+        the synchronous channel.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        interface = cast(hislip.Instrument, self.interface)
+        interface.complete_terminate()
+        return StatusCode.success
 
     def _get_attribute(self, attribute: ResourceAttribute) -> Tuple[Any, StatusCode]:
         """Get the value for a given VISA attribute for this session.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -338,7 +338,7 @@ class TCPIPInstrHiSLIP(Session):
 
         return stb, errorcode
 
-    def terminate(self, job_id: VISAJobID = None) -> StatusCode:
+    def terminate(self, job_id: VISAJobID | None = None) -> StatusCode:
         """Cancel a pending I/O operation on this session.
 
         Corresponds to viTerminate function of the VISA library.
@@ -348,9 +348,20 @@ class TCPIPInstrHiSLIP(Session):
         StatusCode.error_abort and automatically reset the HiSLIP protocol
         state so the session is ready for further I/O.
 
+        .. note::
+
+            This implementation goes beyond what mainstream VISA libraries
+            (e.g. Keysight IO Libraries) provide for synchronous HiSLIP reads.
+            Keysight's ``viTerminate()`` returns ``VI_SUCCESS`` but does not
+            actually cancel a blocked synchronous ``viRead()``; the read
+            continues until the normal timeout expires.  This implementation
+            truly cancels the blocked read via a cancel pipe and performs a
+            HiSLIP device clear to re-sync the protocol.  Code relying on
+            this behavior may not be portable to other VISA backends.
+
         Parameters
         ----------
-        job_id : VISAJobID, optional
+        job_id : VISAJobID | None, optional
             Specifies an operation identifier.  If None, aborts all calls
             on this session.
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from pyvisa import attributes, constants, errors, rname
 from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
+from pyvisa.typing import VISAJobID
 
 from .common import LOGGER, int_to_byte
 from .protocols import hislip, rpc, vxi11
@@ -274,6 +275,9 @@ class TCPIPInstrHiSLIP(Session):
             )
 
         except hislip.HiSLIPInterruptedError:
+            # terminate() was called from another thread.  Reset the HiSLIP
+            # protocol state so the session is ready for further I/O.
+            self.interface.complete_terminate()
             data, status = b"", StatusCode.error_abort
 
         except socket.timeout:
@@ -334,18 +338,21 @@ class TCPIPInstrHiSLIP(Session):
 
         return stb, errorcode
 
-    def terminate(self) -> StatusCode:
+    def terminate(self, job_id: VISAJobID = None) -> StatusCode:
         """Cancel a pending I/O operation on this session.
 
         Corresponds to viTerminate function of the VISA library.
 
         Thread-safe: may be called from any thread while another thread is
         blocked in read().  The blocked read() will return with
-        StatusCode.error_abort.
+        StatusCode.error_abort and automatically reset the HiSLIP protocol
+        state so the session is ready for further I/O.
 
-        After the blocked operation returns, the caller MUST call
-        complete_terminate() to reset the HiSLIP protocol before performing
-        further I/O.
+        Parameters
+        ----------
+        job_id : VISAJobID, optional
+            Specifies an operation identifier.  If None, aborts all calls
+            on this session.
 
         Returns
         -------
@@ -355,23 +362,6 @@ class TCPIPInstrHiSLIP(Session):
         """
         interface = cast(hislip.Instrument, self.interface)
         interface.terminate()
-        return StatusCode.success
-
-    def complete_terminate(self) -> StatusCode:
-        """Reset HiSLIP protocol state after terminate().
-
-        Must be called after terminate() and after the blocked read thread
-        has exited.  Performs a full HiSLIP device clear to re-synchronize
-        the synchronous channel.
-
-        Returns
-        -------
-        StatusCode
-            Return value of the library call.
-
-        """
-        interface = cast(hislip.Instrument, self.interface)
-        interface.complete_terminate()
         return StatusCode.success
 
     def _get_attribute(self, attribute: ResourceAttribute) -> Tuple[Any, StatusCode]:

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -196,13 +196,21 @@ class TestInstrumentTerminate:
     """Test Instrument.terminate() and complete_terminate() via mocking."""
 
     def test_terminate_calls_cancel(self):
-        """Instrument.terminate() signals the CancellableSocket cancel pipe."""
+        """Instrument.terminate() signals cancel only when receiving."""
+        import threading
         from pyvisa_py.protocols.hislip import Instrument
 
         inst = object.__new__(Instrument)
         mock_sync = MagicMock(spec=CancellableSocket)
         inst._sync = mock_sync
+        inst._receiving = threading.Event()
 
+        # When no receive is in progress, terminate is a no-op
+        inst.terminate()
+        mock_sync.cancel.assert_not_called()
+
+        # When a receive is in progress, terminate signals cancel
+        inst._receiving.set()
         inst.terminate()
         mock_sync.cancel.assert_called_once()
 

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -197,7 +197,6 @@ class TestInstrumentTerminate:
 
     def test_terminate_calls_cancel(self):
         """Instrument.terminate() signals cancel only when receiving."""
-        import threading
         from pyvisa_py.protocols.hislip import Instrument
 
         inst = object.__new__(Instrument)

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""Tests for HiSLIP terminate (viTerminate) support.
+
+Tests the CancellableSocket, HiSLIPInterruptedError, and the terminate/
+complete_terminate flow without requiring a real instrument.
+"""
+
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from pyvisa_py.protocols.hislip import (
+    HEADER_FORMAT,
+    MESSAGETYPE,
+    CancellableSocket,
+    HiSLIPInterruptedError,
+)
+
+
+class TestCancellableSocket:
+    """Unit tests for the CancellableSocket wrapper."""
+
+    def setup_method(self):
+        """Create a socket pair for testing."""
+        self.server, self.client_raw = socket.socketpair()
+        self.client = CancellableSocket(self.client_raw)
+
+    def teardown_method(self):
+        self.client.close()
+        self.server.close()
+
+    def test_recv_into_normal(self):
+        """Normal recv_into passes through to the underlying socket."""
+        self.server.sendall(b"hello")
+        buf = bytearray(5)
+        n = self.client.recv_into(buf, 5)
+        assert n == 5
+        assert buf == b"hello"
+
+    def test_recv_into_cancel(self):
+        """cancel() from another thread unblocks a pending recv_into."""
+        buf = bytearray(100)
+        result = {}
+
+        def reader():
+            try:
+                self.client.recv_into(buf, 100)
+                result["error"] = None
+            except HiSLIPInterruptedError as e:
+                result["error"] = e
+
+        t = threading.Thread(target=reader)
+        t.start()
+
+        # Give the reader thread time to enter select()
+        time.sleep(0.1)
+
+        # Cancel from the main thread
+        self.client.cancel()
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "Reader thread did not exit"
+        assert isinstance(result.get("error"), HiSLIPInterruptedError)
+
+    def test_cancel_before_recv_into(self):
+        """cancel() before recv_into causes immediate HiSLIPInterruptedError."""
+        self.client.cancel()
+        buf = bytearray(100)
+        with pytest.raises(HiSLIPInterruptedError):
+            self.client.recv_into(buf, 100)
+
+    def test_cancel_drain_allows_subsequent_recv(self):
+        """After draining the cancel pipe, normal recv_into works again."""
+        self.client.cancel()
+        self.client._drain_cancel()
+
+        self.server.sendall(b"data")
+        buf = bytearray(4)
+        n = self.client.recv_into(buf, 4)
+        assert n == 4
+        assert buf == b"data"
+
+    def test_recv_into_timeout(self):
+        """recv_into honours the underlying socket timeout."""
+        self.client_raw.settimeout(0.1)
+        buf = bytearray(100)
+        with pytest.raises(socket.timeout):
+            self.client.recv_into(buf, 100)
+
+    def test_sendall_delegates(self):
+        """sendall delegates to the underlying socket."""
+        self.client.sendall(b"outgoing")
+        data = self.server.recv(100)
+        assert data == b"outgoing"
+
+    def test_cancel_prioritized_over_data(self):
+        """When both data and cancel are ready, cancel takes priority."""
+        self.server.sendall(b"data")
+        time.sleep(0.05)  # let the data arrive
+        self.client.cancel()
+        time.sleep(0.05)  # let the cancel signal arrive
+
+        buf = bytearray(100)
+        with pytest.raises(HiSLIPInterruptedError):
+            self.client.recv_into(buf, 100)
+
+
+class TestHiSLIPInterruptedInHeader:
+    """Test that Interrupted messages in _next_data_header raise properly."""
+
+    def _make_hislip_header(
+        self,
+        msg_type: str,
+        control_code: int,
+        message_parameter: int,
+        payload_length: int,
+    ) -> bytes:
+        return struct.pack(
+            HEADER_FORMAT,
+            b"HS",
+            MESSAGETYPE[msg_type],
+            control_code,
+            message_parameter,
+            payload_length,
+        )
+
+    def setup_method(self):
+        """Create a socket pair simulating a HiSLIP sync channel."""
+        self.server, self.client_raw = socket.socketpair()
+        self.client = CancellableSocket(self.client_raw)
+
+    def teardown_method(self):
+        self.client.close()
+        self.server.close()
+
+    def test_interrupted_message_raises(self):
+        """Receiving an Interrupted message raises HiSLIPInterruptedError."""
+        # We can't easily construct an Instrument without a real server,
+        # so we test _next_data_header indirectly by testing that RxHeader
+        # + our handling works.
+        #
+        # Send an Interrupted header on the "sync" channel.
+        interrupted_hdr = self._make_hislip_header("Interrupted", 0, 0xFFFF_FF00, 0)
+        self.server.sendall(interrupted_hdr)
+
+        # Read it as an RxHeader and verify msg_type
+        from pyvisa_py.protocols.hislip import RxHeader
+
+        header = RxHeader(self.client)
+        assert header.msg_type == "Interrupted"
+        assert header.message_parameter == 0xFFFF_FF00
+
+
+class TestTerminateConcurrency:
+    """Integration test: terminate() cancels a blocked receive."""
+
+    def test_terminate_unblocks_blocked_recv(self):
+        """Simulate a blocked receive and cancel it via terminate()."""
+        server, client_raw = socket.socketpair()
+        client = CancellableSocket(client_raw)
+
+        result = {}
+
+        def blocked_reader():
+            """Simulates the receive path: tries to read a full HiSLIP message."""
+            from pyvisa_py.protocols.hislip import receive_exact_into
+
+            buf = bytearray(1024)
+            try:
+                receive_exact_into(client, buf)
+                result["ok"] = True
+            except HiSLIPInterruptedError:
+                result["interrupted"] = True
+            except RuntimeError:
+                result["dropped"] = True
+
+        t = threading.Thread(target=blocked_reader)
+        t.start()
+        time.sleep(0.1)  # let the reader enter select()
+
+        # terminate = write to cancel pipe
+        client.cancel()
+
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "Reader thread did not exit after cancel"
+        assert result.get("interrupted") is True, f"Got: {result}"
+
+        client.close()
+        server.close()

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -9,6 +9,7 @@ import socket
 import struct
 import threading
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -106,6 +107,50 @@ class TestCancellableSocket:
         with pytest.raises(HiSLIPInterruptedError):
             self.client.recv_into(buf, 100)
 
+    def test_recv_into_bypass_when_cancel_disabled(self):
+        """recv_into bypasses select() when _cancel_enabled is False."""
+        self.client._cancel_enabled = False
+        self.server.sendall(b"bypass")
+        buf = bytearray(6)
+        n = self.client.recv_into(buf, 6)
+        assert n == 6
+        assert buf == b"bypass"
+
+    def test_cancel_idempotent(self):
+        """Multiple cancel() calls don't raise — already-signalled is a no-op."""
+        self.client.cancel()
+        self.client.cancel()  # should not raise
+        # Drain and verify socket is still usable
+        self.client.drain_cancel()
+        self.server.sendall(b"ok")
+        buf = bytearray(2)
+        n = self.client.recv_into(buf, 2)
+        assert n == 2
+        assert buf == b"ok"
+
+    def test_socket_options_preserved(self):
+        """Socket options set before wrapping are preserved."""
+        raw_server, raw_client = socket.socketpair()
+        raw_client.settimeout(3.5)
+        wrapped = CancellableSocket(raw_client)
+        assert wrapped.gettimeout() == 3.5
+        wrapped.close()
+        raw_server.close()
+
+
+class TestHiSLIPInterruptedError:
+    """Test HiSLIPInterruptedError attributes and formatting."""
+
+    def test_default_message_id(self):
+        err = HiSLIPInterruptedError()
+        assert err.message_id == 0
+        assert "message_id=0x0" in str(err)
+
+    def test_custom_message_id(self):
+        err = HiSLIPInterruptedError(0xDEAD)
+        assert err.message_id == 0xDEAD
+        assert "0xdead" in str(err)
+
 
 class TestHiSLIPInterruptedInHeader:
     """Test that Interrupted messages in _next_data_header raise properly."""
@@ -137,20 +182,70 @@ class TestHiSLIPInterruptedInHeader:
 
     def test_interrupted_message_raises(self):
         """Receiving an Interrupted message raises HiSLIPInterruptedError."""
-        # We can't easily construct an Instrument without a real server,
-        # so we test _next_data_header indirectly by testing that RxHeader
-        # + our handling works.
-        #
-        # Send an Interrupted header on the "sync" channel.
         interrupted_hdr = self._make_hislip_header("Interrupted", 0, 0xFFFF_FF00, 0)
         self.server.sendall(interrupted_hdr)
 
-        # Read it as an RxHeader and verify msg_type
         from pyvisa_py.protocols.hislip import RxHeader
 
         header = RxHeader(self.client)
         assert header.msg_type == "Interrupted"
         assert header.message_parameter == 0xFFFF_FF00
+
+
+class TestInstrumentTerminate:
+    """Test Instrument.terminate() and complete_terminate() via mocking."""
+
+    def test_terminate_calls_cancel(self):
+        """Instrument.terminate() signals the CancellableSocket cancel pipe."""
+        from pyvisa_py.protocols.hislip import Instrument
+
+        inst = object.__new__(Instrument)
+        mock_sync = MagicMock(spec=CancellableSocket)
+        inst._sync = mock_sync
+
+        inst.terminate()
+        mock_sync.cancel.assert_called_once()
+
+    def test_complete_terminate_resets_state(self):
+        """complete_terminate() drains cancel, clears socket, does device clear."""
+        from pyvisa_py.protocols.hislip import Instrument
+
+        inst = object.__new__(Instrument)
+        mock_sync = MagicMock(spec=CancellableSocket)
+        mock_sync.gettimeout.return_value = 5.0
+        # Make recv return empty to end drain loop
+        mock_sync.recv.side_effect = BlockingIOError
+        inst._sync = mock_sync
+        inst._timeout = 5.0
+        inst._message_id = 0xABCD
+        inst._last_message_id = 0x1234
+        inst._rmt = 1
+        inst._payload_remaining = 42
+        inst._msg_type = "Data"
+
+        # Mock the async channel methods that complete_terminate calls
+        inst.async_device_clear = MagicMock(return_value=0)
+        inst.device_clear_complete = MagicMock(return_value=0)
+
+        # Mock RxHeader to return an Interrupted message
+        mock_header = MagicMock()
+        mock_header.msg_type = "Interrupted"
+        mock_header.payload_length = 0
+        with patch("pyvisa_py.protocols.hislip.RxHeader", return_value=mock_header):
+            inst.complete_terminate()
+
+        # Verify state was reset
+        assert inst._message_id == 0xFFFF_FF00
+        assert inst._last_message_id is None
+        assert inst._rmt == 0
+        assert inst._payload_remaining == 0
+        assert inst._msg_type == ""
+
+        # Verify cancel pipe was drained
+        mock_sync.drain_cancel.assert_called_once()
+        # Verify device clear was performed
+        inst.async_device_clear.assert_called_once()
+        inst.device_clear_complete.assert_called_once()
 
 
 class TestTerminateConcurrency:
@@ -189,3 +284,127 @@ class TestTerminateConcurrency:
 
         client.close()
         server.close()
+
+
+class TestSessionTerminateBase:
+    """Test Session.terminate() base class default."""
+
+    def test_base_session_terminate_returns_nonsupported(self):
+        from pyvisa.constants import StatusCode
+        from pyvisa_py.sessions import Session
+
+        # Session is abstract, so test the default through a minimal mock
+        sess = MagicMock(spec=Session)
+        result = Session.terminate(sess)
+        assert result == StatusCode.error_nonsupported_operation
+
+    def test_base_session_terminate_accepts_job_id(self):
+        from pyvisa.constants import StatusCode
+        from pyvisa_py.sessions import Session
+
+        sess = MagicMock(spec=Session)
+        result = Session.terminate(sess, job_id=None)
+        assert result == StatusCode.error_nonsupported_operation
+
+
+class TestTCPIPInstrHiSLIPTerminate:
+    """Test TCPIPInstrHiSLIP.terminate() and read() abort path."""
+
+    def _make_session(self):
+        """Create a TCPIPInstrHiSLIP with a mocked HiSLIP Instrument."""
+        from pyvisa_py.tcpip import TCPIPInstrHiSLIP
+
+        sess = object.__new__(TCPIPInstrHiSLIP)
+        sess.interface = MagicMock()
+        return sess
+
+    def test_terminate_calls_interface(self):
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        result = sess.terminate()
+        assert result == StatusCode.success
+        sess.interface.terminate.assert_called_once()
+
+    def test_terminate_accepts_job_id(self):
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        result = sess.terminate(job_id=None)
+        assert result == StatusCode.success
+
+    def test_read_abort_calls_complete_terminate(self):
+        """When read() catches HiSLIPInterruptedError, it auto-resets."""
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        sess.interface.receive.side_effect = HiSLIPInterruptedError(0)
+
+        data, status = sess.read(1024)
+        assert data == b""
+        assert status == StatusCode.error_abort
+        sess.interface.complete_terminate.assert_called_once()
+
+    def test_read_timeout(self):
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        sess.interface.receive.side_effect = socket.timeout("timed out")
+
+        data, status = sess.read(1024)
+        assert data == b""
+        assert status == StatusCode.error_timeout
+
+    def test_read_success_rmt(self):
+        """read() returns success_termination_character_read when rmt is set."""
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        sess.interface.receive.return_value = b"*IDN? response\n"
+        sess.interface._rmt = 1
+
+        data, status = sess.read(4096)
+        assert data == b"*IDN? response\n"
+        assert status == StatusCode.success_termination_character_read
+
+    def test_read_success_max_count(self):
+        """read() returns success_max_count_read when buffer is full."""
+        from pyvisa.constants import StatusCode
+
+        sess = self._make_session()
+        sess.interface.receive.return_value = b"abcd"
+        sess.interface._rmt = 0
+
+        data, status = sess.read(4)
+        assert data == b"abcd"
+        assert status == StatusCode.success_max_count_read
+
+
+class TestHighlevelTerminate:
+    """Test PyVisaLibrary.terminate() dispatcher."""
+
+    def test_terminate_dispatches_to_session(self):
+        from pyvisa.constants import StatusCode
+        from pyvisa_py.highlevel import PyVisaLibrary
+
+        lib = object.__new__(PyVisaLibrary)
+        mock_sess = MagicMock()
+        mock_sess.terminate.return_value = StatusCode.success
+        lib.sessions = {42: mock_sess}
+        # Stub handle_return_value to pass through
+        lib.handle_return_value = lambda sess, val: val
+
+        result = lib.terminate(42, None, None)
+        assert result == StatusCode.success
+        mock_sess.terminate.assert_called_once_with(None)
+
+    def test_terminate_invalid_session(self):
+        from pyvisa.constants import StatusCode
+        from pyvisa_py.highlevel import PyVisaLibrary
+
+        lib = object.__new__(PyVisaLibrary)
+        lib.sessions = {}
+        lib.handle_return_value = lambda sess, val: val
+
+        result = lib.terminate(999, None, None)
+        assert result == StatusCode.error_invalid_object

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -21,12 +21,12 @@ from pyvisa_py.protocols.hislip import (
 
 
 class TestCancellableSocket:
-    """Unit tests for the CancellableSocket wrapper."""
+    """Unit tests for the CancellableSocket subclass."""
 
     def setup_method(self):
         """Create a socket pair for testing."""
-        self.server, self.client_raw = socket.socketpair()
-        self.client = CancellableSocket(self.client_raw)
+        self.server, client_raw = socket.socketpair()
+        self.client = CancellableSocket(client_raw)
 
     def teardown_method(self):
         self.client.close()
@@ -74,7 +74,7 @@ class TestCancellableSocket:
     def test_cancel_drain_allows_subsequent_recv(self):
         """After draining the cancel pipe, normal recv_into works again."""
         self.client.cancel()
-        self.client._drain_cancel()
+        self.client.drain_cancel()
 
         self.server.sendall(b"data")
         buf = bytearray(4)
@@ -83,8 +83,8 @@ class TestCancellableSocket:
         assert buf == b"data"
 
     def test_recv_into_timeout(self):
-        """recv_into honours the underlying socket timeout."""
-        self.client_raw.settimeout(0.1)
+        """recv_into honours the socket timeout."""
+        self.client.settimeout(0.1)
         buf = bytearray(100)
         with pytest.raises(socket.timeout):
             self.client.recv_into(buf, 100)
@@ -128,8 +128,8 @@ class TestHiSLIPInterruptedInHeader:
 
     def setup_method(self):
         """Create a socket pair simulating a HiSLIP sync channel."""
-        self.server, self.client_raw = socket.socketpair()
-        self.client = CancellableSocket(self.client_raw)
+        self.server, client_raw = socket.socketpair()
+        self.client = CancellableSocket(client_raw)
 
     def teardown_method(self):
         self.client.close()


### PR DESCRIPTION
- [x] Closes #566
- [x] Executed ``ruff check && ruff format --check`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

## Summary

Implement `viTerminate()` for HiSLIP TCPIP sessions — the VISA function for
cross-thread I/O cancellation that was previously unimplemented
(`VisaLibraryBase.terminate()` raised `NotImplementedError`).

### Problem

When a thread is blocked in `hislip.Instrument.receive()` waiting for a long
SCPI operation, there is no way to cancel it from another thread. The only
workaround is `socket.shutdown(SHUT_RDWR)`, which destroys the TCP connection
and forces a full session reconnect.

### Approach

**CancellableSocket** — wraps the HiSLIP sync socket so that `recv_into()`
uses `select()` to watch both the data socket and a cancel pipe
(`socket.socketpair()`). When `cancel()` is called from another thread, the
blocked `select()` returns immediately with `HiSLIPInterruptedError` (mapped
to `StatusCode.error_abort`).

This is a drop-in replacement — all existing code that calls `sock.recv_into()`
(`receive_exact_into`, `RxHeader`, `receive_flush`) gets cancellation support
transparently.

**Two-phase terminate:**
- `terminate()` — instant, thread-safe. Writes to the cancel pipe.
- `complete_terminate()` — called after the read thread exits. Performs a full
  HiSLIP device clear per IVI-6.1 to re-sync the protocol.

**Interrupted message handling** — `_next_data_header()` now properly handles
`Interrupted` messages per IVI-6.1 Section 3.8 (previously silently discarded).

### Changes

| File | Change |
|------|--------|
| `protocols/hislip.py` | `CancellableSocket`, `HiSLIPInterruptedError`, `terminate()` + `complete_terminate()`, `Interrupted` handling |
| `tcpip.py` | `TCPIPInstrHiSLIP.terminate()` + `complete_terminate()`, catch abort in `read()` |
| `sessions.py` | `Session.terminate()` base method |
| `highlevel.py` | `PyVisaLibrary.terminate()` dispatcher |
| `testsuite/test_hislip_terminate.py` | 9 unit tests |

~270 lines added, 0 removed. All existing tests pass.

## Test plan

- [x] `TestCancellableSocket` — normal recv, cross-thread cancel, cancel-before-recv, drain+reuse, timeout, delegation, cancel priority
- [x] `TestHiSLIPInterruptedInHeader` — Interrupted message parsed correctly
- [x] `TestTerminateConcurrency` — cancel unblocks `receive_exact_into` from another thread
- [x] Full existing test suite passes (47 passed, 0 failed)
- [x] Live instrument test (would need a HiSLIP instrument)