### PR TITLE
Fix VXI11 read timeout behavior - addresses issue #575

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@ PyVISA-py Changelog
   (self-pipe trick on recv_into), enabling cross-thread I/O cancellation
   without destroying the session. Also handle HiSLIP Interrupted messages
   in the receive path. Closes #566
+- Fixed VXI-11 read timeouthandling. When reads were splitdown into multiple read 
+  chunks the timeout value for each chunk was calculated wrongly. This resulted in 
+  very high timeout values which had to be set.
+  A second addressed issue is that timeout values never decrement to 0. A timeout value 
+  of 0 is undefined in VXI-11 standard. It can mean "timeout immediately if no data 
+  is in buffer" or "block permanently until transfer is finished".
 
 0.8.1 (04-09-2025)
 ------------------

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -614,15 +614,19 @@ class TCPIPInstrVxi11(Session):
         while reason & end_reason == 0:
             # Decrease timeout so that the total timeout does not get larger
             # than the specified timeout.
-            
-            # Calculate timeout for current chunk. 
-            # Limit the minimum timeout to 10ms, because 0 is undefined 
+
+            # Calculate timeout for current chunk.
+            # Limit the minimum timeout to 10ms, because 0 is undefined
             # according to VXI-11 spec (done also by Visas)
-            chunk_timeout = max(10, timeout - int((time.time() - start_time) * 1000)) 
+            chunk_timeout = max(10, timeout - int((time.time() - start_time) * 1000))
             error, reason, data = read_fun(
-                self.link, chunk_length, chunk_timeout, self.lock_timeout, flags, term_char
+                self.link,
+                chunk_length,
+                chunk_timeout,
+                self.lock_timeout,
+                flags,
+                term_char,
             )
-            
 
             if error == vxi11.ErrorCodes.io_timeout:
                 return bytes(read_data), StatusCode.error_timeout

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -614,10 +614,15 @@ class TCPIPInstrVxi11(Session):
         while reason & end_reason == 0:
             # Decrease timeout so that the total timeout does not get larger
             # than the specified timeout.
-            timeout = max(0, timeout - int((time.time() - start_time) * 1000))
+            
+            # Calculate timeout for current chunk. 
+            # Limit the minimum timeout to 10ms, because 0 is undefined 
+            # according to VXI-11 spec (done also by Visas)
+            chunk_timeout = max(10, timeout - int((time.time() - start_time) * 1000)) 
             error, reason, data = read_fun(
-                self.link, chunk_length, timeout, self.lock_timeout, flags, term_char
+                self.link, chunk_length, chunk_timeout, self.lock_timeout, flags, term_char
             )
+            
 
             if error == vxi11.ErrorCodes.io_timeout:
                 return bytes(read_data), StatusCode.error_timeout


### PR DESCRIPTION
This fixes the issue discussed in this Issue report: https://github.com/pyvisa/pyvisa-py/issues/575

1. Changes made:
Adjusted the VXI11 read function timeout handling. See Issue #575  for details

1. Yes, I ensured the code is properly formatted

1. No new unit test required for this minimalistic change

- Closes #575
- Added an entry to the CHANGES file
