### PR TITLE
gpib: fix EOS for read

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ PyVISA-py Changelog
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
   Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
+- Pass termchar information to USBTMC and GPIO devices when reading.
 
 0.8.1 (04-09-2025)
 ------------------

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -467,14 +467,16 @@ class _GPIBCommon(Session):
 
         reader = lambda: ifc.read(count)  # noqa: E731
 
-        if (self.attrs[ResourceAttribute.termchar] is None
-            or not self.attrs[ResourceAttribute.termchar_enabled]):
-            ifc.config(0x0C, 0)         # IbcEOSrd
+        if (
+            self.attrs[ResourceAttribute.termchar] is None
+            or not self.attrs[ResourceAttribute.termchar_enabled]
+        ):
+            ifc.config(0x0C, 0)  # IbcEOSrd
         else:
             termchar = self.attrs[ResourceAttribute.termchar]
             ifc.config(0x0F, termchar)  # IbcEOSchar
-            ifc.config(0x0E, 1)         # IbcEOScmp
-            ifc.config(0x0C, 1)         # IbcEOSrd
+            ifc.config(0x0E, 1)  # IbcEOScmp
+            ifc.config(0x0C, 1)  # IbcEOSrd
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -467,6 +467,15 @@ class _GPIBCommon(Session):
 
         reader = lambda: ifc.read(count)  # noqa: E731
 
+        if (self.attrs[ResourceAttribute.termchar] is None
+            or not self.attrs[ResourceAttribute.termchar_enabled]):
+            ifc.config(0x0C, 0)         # IbcEOSrd
+        else:
+            termchar = self.attrs[ResourceAttribute.termchar]
+            ifc.config(0x0F, termchar)  # IbcEOSchar
+            ifc.config(0x0E, 1)         # IbcEOScmp
+            ifc.config(0x0C, 1)         # IbcEOSrd
+
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 
     def write(self, data: bytes) -> Tuple[int, StatusCode]:


### PR DESCRIPTION
Add actual TERMCHAR support to GPIB interface
    
Use the TERMCHAR and TERM_CHAR_EN attributes to configure the GPIB interface prior to each read.  Partial fix for #596
    
This allows the GPIB device class to be used with devices such as the HP 8903B which do not signal EOI at the end of input and must depend on termination-character matching by the interface.


- [ X] Closes # 596 (partial fix)
- [ X] Added an entry to the CHANGES file
