### PR TITLE
USBTMC: pass termchar through to interface for EOS processing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,7 +23,7 @@ PyVISA-py Changelog
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
   Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
-- Pass termchar information to USBTMC and GPIO devices when reading.
+- Pass termchar information to USBTMC devices when reading.  PR#598
 
 0.8.1 (04-09-2025)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ PyVISA-py Changelog
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
   Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
+- Pass termchar information to USBTMC and GPIO devices when reading.
 
 0.8.1 (04-09-2025)
 ------------------

--- a/pyvisa_py/protocols/usbtmc.py
+++ b/pyvisa_py/protocols/usbtmc.py
@@ -320,7 +320,7 @@ class USBRaw:
         except usb.core.USBError as e:
             raise ValueError(str(e))
 
-    def read(self, size):
+    def read(self, size, termchar):
         """Receive raw bytes to the instrument.
 
         :param size: number of bytes to receive
@@ -515,7 +515,7 @@ class USBTMC(USBRaw):
 
         return size
 
-    def read(self, size):
+    def read(self, size, termchar):
         usbtmc_header_size = 12
         eom = False
 
@@ -528,7 +528,7 @@ class USBTMC(USBRaw):
             received_transfer = bytearray()
             btag = self._btag.next()
 
-            req = BulkInMessage.build_array(btag, size, None)
+            req = BulkInMessage.build_array(btag, size, termchar)
             raw_write(req)
 
             try:

--- a/pyvisa_py/usb.py
+++ b/pyvisa_py/usb.py
@@ -164,7 +164,7 @@ class USBSession(Session):
         def _usb_reader():
             """Data reader identifying usb timeout exception."""
             try:
-                return self.interface.read(count)
+                return self.interface.read(count, term_char if term_char_en else None)
             except usb.USBError as exc:
                 if exc.errno in (errno.ETIMEDOUT, -errno.ETIMEDOUT):
                     raise USBTimeoutException()


### PR DESCRIPTION
Add actual TERMCHAR support to USBTMC interface.  Partial fix
for #596
    
Plumb the termination-character infrastructure down to the USBTMC protocol, setting the attributes field for the "device dependent data in request" packet properly.
    
This allows the USBTMC class to be used with USBTMC-based GPIB interfaces (specifically Xyphro), with devices such as the HP 8903B which do not signal EOI at the end of input and must depend on termination-character matching by the interface.

- [X] Closes #596 (partial fix)
- [X] Added an entry to the CHANGES file
