### PR TITLE
Implement EOS processing for GPIB interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ PyVISA-py Changelog
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
   Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
+- Fix read timeouts when accessing older GPIB devices which do not signal EOI.
+  Implemented for USBTMC (#598) and GPIB (#599)
 
 0.8.1 (04-09-2025)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -23,8 +23,8 @@ PyVISA-py Changelog
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
   Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
-- Fix read timeouts when accessing older GPIB devices which do not signal EOI.
-  Implemented for USBTMC (#598) and GPIB (#599)
+- Pass termchar information to USBTMC devices when reading PR #598
+- Properly configure termchar on GPIB devices. This fix timeout issues for old GPIB devices which do not signal EOI PR #599
 
 0.8.1 (04-09-2025)
 ------------------

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -721,7 +721,7 @@ class _GPIBCommon(Session):
         elif attribute == ResourceAttribute.termchar:
             if isinstance(attribute_state, int):
                 ifc.config(0x0F, attribute_state)  ## IbcEOSchar
-                ifc.config(0x0E, 1)                ## IbcEOScmp
+                ifc.config(0x0E, 1)  ## IbcEOScmp
                 return StatusCode.success
             else:
                 return StatusCode.error_nonsupported_attribute_state

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -371,15 +371,19 @@ class _GPIBCommon(Session):
         # Bus wide operation
         self.controller = Gpib(name=minor)
 
-        # Force timeout setting to interface
+        # Force timeout and termchar settings to interface
         self.set_attribute(
             constants.ResourceAttribute.timeout_value,
             attributes.AttributesByID[constants.VI_ATTR_TMO_VALUE].default,
         )
-
-        for name in ("TERMCHAR", "TERMCHAR_EN"):
-            attribute = getattr(constants, "VI_ATTR_" + name)
-            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+        self.set_attribute(
+            constants.ResourceAttribute.termchar,
+            attributes.AttributesByID[constants.VI_ATTR_TERMCHAR].default,
+        )
+        self.set_attribute(
+            constants.ResourceAttribute.termchar_enabled,
+            attributes.AttributesByID[constants.VI_ATTR_TERMCHAR_EN].default,
+        )
 
     def _get_timeout(
         self, attribute: constants.ResourceAttribute
@@ -630,6 +634,12 @@ class _GPIBCommon(Session):
         elif attribute == ResourceAttribute.interface_type:
             return constants.InterfaceType.gpib, StatusCode.success
 
+        elif attribute == ResourceAttribute.termchar:
+            return ifc.ask(0x0F), StatusCode.success
+
+        elif attribute == ResourceAttribute.termchar_enabled:
+            return ifc.ask(0x0C), StatusCode.success
+
         raise UnknownAttribute(attribute)
 
     def _set_attribute(
@@ -704,6 +714,21 @@ class _GPIBCommon(Session):
             # IbcEOT 0x4
             if isinstance(attribute_state, int):
                 ifc.config(4, attribute_state)
+                return StatusCode.success
+            else:
+                return StatusCode.error_nonsupported_attribute_state
+
+        elif attribute == ResourceAttribute.termchar:
+            if isinstance(attribute_state, int):
+                ifc.config(0x0F, attribute_state)  ## IbcEOSchar
+                ifc.config(0x0E, 1)                ## IbcEOScmp
+                return StatusCode.success
+            else:
+                return StatusCode.error_nonsupported_attribute_state
+
+        elif attribute == ResourceAttribute.termchar_enabled:
+            if isinstance(attribute_state, int):
+                ifc.config(0x0C, attribute_state)  ## IbcEOSrd
                 return StatusCode.success
             else:
                 return StatusCode.error_nonsupported_attribute_state


### PR DESCRIPTION
Add code in GPIBsession _get_attribute and _set_attribute to map the TERMCHAR and TERMCHAR_EN attributes into the proper GPIB configuration settings.

This allows GPIB reads to work correctly, when directed at older GPIB devices which do not signal EOI at the end of their talk output, but depend on EOS character matching.

- [X] Closes #596 (partial fix here, the rest is in #598)
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
