### PR TITLE
vxi-11: doing readstb inside srq handler is not standard and potentially breaking

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling, as it is not standard behaviour, may confuse instruments, and does not cache the SRQ bit as would be required. Closes #603
+- Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling. 
+  It is not standard behaviour, may confuse instruments, and does not 
+  cache the SRQ bit as would be required. Closes #603 PR #606
 - Added read_stb, assert_trigger and gpib_control_run functions to usbtmc PR #532
 - Implement viTerminate() for HiSLIP sessions using a CancellableSocket
   (self-pipe trick on recv_into), enabling cross-thread I/O cancellation

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling, as it is not standard behaviour, may confuse instruments, and does not cache the SRQ bit as would be required. Closes #603
 - Added read_stb, assert_trigger and gpib_control_run functions to usbtmc PR #532
 - Implement viTerminate() for HiSLIP sessions using a CancellableSocket
   (self-pipe trick on recv_into), enabling cross-thread I/O cancellation

--- a/pyvisa_py/events.py
+++ b/pyvisa_py/events.py
@@ -46,7 +46,6 @@ class EventContext:
     """Immutable description of a single VISA event occurrence."""
 
     event_type: constants.EventType
-    status_byte: int = 0
     timestamp: float = field(default_factory=time.time)
     context_id: int = field(default_factory=lambda: random.getrandbits(32))
 

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -498,12 +498,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
             # Defensive: session may have been closed while we were spawned
             if self.session.interface is None or self.session.link == 0:
                 return
-            stb, status = self.session.read_stb()
-            if status == StatusCode.success and (stb & STB_RQS_BIT):
-                ctx = EventContext(
-                    event_type=constants.EventType.service_request,
-                    status_byte=stb,
-                )
-                self.session._fire_event(constants.EventType.service_request, ctx)
+            ctx = EventContext(
+                event_type=constants.EventType.service_request,
+            )
+            self.session._fire_event(constants.EventType.service_request, ctx)
         except Exception:
             LOGGER.exception("Error handling VXI-11 SRQ interrupt")

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -17,7 +17,6 @@ import struct
 import threading
 
 from pyvisa import constants
-from pyvisa.constants import StatusCode
 
 from ..common import LOGGER
 from ..events import EventContext

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -37,7 +37,6 @@ class TestEventContext:
     def test_defaults(self):
         ctx = EventContext(event_type=constants.EventType.service_request)
         assert ctx.event_type == constants.EventType.service_request
-        assert ctx.status_byte == 0
         assert ctx.timestamp <= time.time()
         assert isinstance(ctx.context_id, int)
         assert 0 <= ctx.context_id < 2**32
@@ -51,12 +50,10 @@ class TestEventContext:
     def test_explicit_values(self):
         ctx = EventContext(
             event_type=constants.EventType.io_completion,
-            status_byte=0x42,
             timestamp=1234.5,
             context_id=99,
         )
         assert ctx.event_type == constants.EventType.io_completion
-        assert ctx.status_byte == 0x42
         assert ctx.timestamp == 1234.5
         assert ctx.context_id == 99
 
@@ -689,7 +686,6 @@ class TestVxi11SrqFlow:
         )
         ctx = EventContext(
             event_type=constants.EventType.service_request,
-            status_byte=0x50,
             context_id=9876,
         )
         # Use the real Session._fire_event logic via a partial call


### PR DESCRIPTION
- [x] Closes #603
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
       There was no documentation of this behaviour
- [x] Added an entry to the CHANGES file


Reasoning is mentioned in #603. The used approach is to remove the `read_stb()`.  The only other feasible approach would require 2 things:
- Add a setting to select enabling it or not. 
- Add a cache of the SRQ bit, like the ICS-9065 does. 

This would however be highly specific to pyvisa-py, for a seldomly used feature, would require a lot of work, and would potentially confuse people. Not worth it.

**Details of the why**, with rewording of the referred issue:

This is about the SRQ handling for VXI-11, where a device can raise the `SRQ` state, and sends an event to the VXI-11 client. 

For connections to single devices, there is no confusion as to who provoked the event. 

But when you connect to a VXI-11.2 gateway (E5810, ICS-9065, and others), the `SRQ` may come from any device on the GPIB bus, as there is only 1 line for the entire bus. One device may have raised the event, but all clients that are connected to any device on the bus (and have event handling activated), will receive the event. **ALL** IVI backends I have tested (NI-Visa, Keysight, R&S) therefore expect the client to then to actively determine which device provoked that event, as you may get false positives. The VXI-11.2 specification mentions this behaviour (Rule B.4.13), and NI-Visa even explicitly mentions the requirement for clients to filter events themselves. 

Determining who really raised the event is easy with IEEE-488.2 compatible devices (using `read_stb()`), but IEEE-488.1 or earlier devices may not support that same method. Some may even freak out over it. So: filtering of the events by some middle man (meaning: pyvisa) is not only non standard, but even potentially breaking on some instruments. The implementation that was in place did the `read_stb()` 'hard wired', without possibility to switch it off.

The implementation that was in place was even more breaking, as once you call `read_stb()`, you 'consume' the SRQ bit, and it is no longer there. The client that then wants to call `read_stb()` to determine if the device really provoked the event (like how it is expected on the other IVI backends), will no longer find any proof of it, and reject the event. So in order to keep compatibility with the other IVI backends, you need the cache that is mentioned above.