### PR TITLE
Call potentially unsupported interrupt channel shutdown procedures only when needed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Removed logs in shutdown introduced by SRQ handling. Closes #609 PR #610
+- Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.
   It is not standard behaviour, may confuse instruments, and does not
   cache the SRQ bit as would be required. Closes #603 PR #606

--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,9 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling. 
-  It is not standard behaviour, may confuse instruments, and does not 
+- Removed logs in shutdown introduced by SRQ handling. Closes #609 PR #610
+- Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.
+  It is not standard behaviour, may confuse instruments, and does not
   cache the SRQ bit as would be required. Closes #603 PR #606
 - Added read_stb, assert_trigger and gpib_control_run functions to usbtmc PR #532
 - Implement viTerminate() for HiSLIP sessions using a CancellableSocket

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -573,7 +573,8 @@ class TCPIPInstrVxi11(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def close(self) -> StatusCode:
-        self._stop_event_monitor()
+        # Calling _stop_event_monitor() here is not necessary because the session manager already does that for you
+        # self._stop_event_monitor()
         try:
             self.interface.destroy_link(self.link)
         except (errors.VisaIOError, socket.error, rpc.RPCError) as e:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -660,9 +660,12 @@ class TCPIPInstrVxi11(Session):
             self._event_state.stop_flag.set()
             try:
                 self.interface.device_enable_srq(self.link, False, b"")
+            except Exception:
+                LOGGER.debug("Error disabling VXI-11 SRQ")
+            try:                
                 self.interface.destroy_intr_chan()
             except Exception:
-                pass  # no need to log this, as the device may have been closed already
+                LOGGER.debug("Error destroying VXI-11 interrupt channel")
             with self._event_state._lock:
                 thread = self._event_state.monitor_thread
                 self._event_state.monitor_thread = None

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -573,6 +573,7 @@ class TCPIPInstrVxi11(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def close(self) -> StatusCode:
+        self._stop_event_monitor()
         try:
             self.interface.destroy_link(self.link)
         except (errors.VisaIOError, socket.error, rpc.RPCError) as e:
@@ -656,16 +657,18 @@ class TCPIPInstrVxi11(Session):
 
     def _stop_event_monitor(self) -> None:
         """Disable events and stop the interrupt server thread."""
+        if self._srq_server is None:
+            return
         with self._srq_lifecycle_lock:
             self._event_state.stop_flag.set()
             try:
                 self.interface.device_enable_srq(self.link, False, b"")
             except Exception:
-                LOGGER.debug("Error disabling VXI-11 SRQ")
+                LOGGER.exception("Error disabling VXI-11 SRQ")
             try:
                 self.interface.destroy_intr_chan()
             except Exception:
-                LOGGER.debug("Error destroying VXI-11 interrupt channel")
+                LOGGER.exception("Error destroying VXI-11 interrupt channel")
             with self._event_state._lock:
                 thread = self._event_state.monitor_thread
                 self._event_state.monitor_thread = None

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -662,7 +662,7 @@ class TCPIPInstrVxi11(Session):
                 self.interface.device_enable_srq(self.link, False, b"")
             except Exception:
                 LOGGER.debug("Error disabling VXI-11 SRQ")
-            try:                
+            try:
                 self.interface.destroy_intr_chan()
             except Exception:
                 LOGGER.debug("Error destroying VXI-11 interrupt channel")

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -573,8 +573,6 @@ class TCPIPInstrVxi11(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def close(self) -> StatusCode:
-        # Calling _stop_event_monitor() here is not necessary because the session manager already does that for you
-        # self._stop_event_monitor()
         try:
             self.interface.destroy_link(self.link)
         except (errors.VisaIOError, socket.error, rpc.RPCError) as e:
@@ -662,12 +660,9 @@ class TCPIPInstrVxi11(Session):
             self._event_state.stop_flag.set()
             try:
                 self.interface.device_enable_srq(self.link, False, b"")
-            except Exception:
-                LOGGER.exception("Error disabling VXI-11 SRQ")
-            try:
                 self.interface.destroy_intr_chan()
             except Exception:
-                LOGGER.exception("Error destroying VXI-11 interrupt channel")
+                pass  # no need to log this, as the device may have been closed already
             with self._event_state._lock:
                 thread = self._event_state.monitor_thread
                 self._event_state.monitor_thread = None

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -678,7 +678,7 @@ class TestVxi11SrqFlow:
         TCPIPInstrVxi11._stop_event_monitor(sess)
         sess.interface.device_enable_srq.assert_not_called()
         sess.interface.destroy_intr_chan.assert_not_called()
-        
+
         # After monitor setup:
         sess = mock_vxi11_session
         sess._event_state.monitor_thread = None
@@ -689,7 +689,6 @@ class TestVxi11SrqFlow:
         TCPIPInstrVxi11._stop_event_monitor(sess)
         sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
         sess.interface.destroy_intr_chan.assert_called_once()
-
 
     def test_fire_event_then_wait_on_event(self, lib_and_session):
         """Simulate an SRQ by calling _fire_event on a mocked session."""

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -669,14 +669,14 @@ class TestVxi11SrqFlow:
             assert result == StatusCode.error_nonsupported_operation
             assert sess._event_state.monitor_thread is None
 
-    def test_stop_event_monitor_calls_disable(self, mock_vxi11_session):
-        from pyvisa_py.tcpip import TCPIPInstrVxi11
+    # def test_stop_event_monitor_calls_disable(self, mock_vxi11_session):
+    #     from pyvisa_py.tcpip import TCPIPInstrVxi11
 
-        sess = mock_vxi11_session
-        sess._event_state.monitor_thread = None
-        TCPIPInstrVxi11._stop_event_monitor(sess)
-        sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
-        sess.interface.destroy_intr_chan.assert_called_once()
+    #     sess = mock_vxi11_session
+    #     sess._event_state.monitor_thread = None
+    #     TCPIPInstrVxi11._stop_event_monitor(sess)
+    #     sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
+    #     sess.interface.destroy_intr_chan.assert_called_once()
 
     def test_fire_event_then_wait_on_event(self, lib_and_session):
         """Simulate an SRQ by calling _fire_event on a mocked session."""

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -669,14 +669,27 @@ class TestVxi11SrqFlow:
             assert result == StatusCode.error_nonsupported_operation
             assert sess._event_state.monitor_thread is None
 
-    # def test_stop_event_monitor_calls_disable(self, mock_vxi11_session):
-    #     from pyvisa_py.tcpip import TCPIPInstrVxi11
+    def test_stop_event_monitor_calls_disable(self, mock_vxi11_session):
+        from pyvisa_py.tcpip import TCPIPInstrVxi11
 
-    #     sess = mock_vxi11_session
-    #     sess._event_state.monitor_thread = None
-    #     TCPIPInstrVxi11._stop_event_monitor(sess)
-    #     sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
-    #     sess.interface.destroy_intr_chan.assert_called_once()
+        # Without monitor setup:
+        sess = mock_vxi11_session
+        sess._event_state.monitor_thread = None
+        TCPIPInstrVxi11._stop_event_monitor(sess)
+        sess.interface.device_enable_srq.assert_not_called()
+        sess.interface.destroy_intr_chan.assert_not_called()
+        
+        # After monitor setup:
+        sess = mock_vxi11_session
+        sess._event_state.monitor_thread = None
+        sess._srq_server = MagicMock()
+        sess._srq_server.shutdown = MagicMock()
+        sess._srq_server.server_close = MagicMock()
+        sess._event_state.stop_flag.set()
+        TCPIPInstrVxi11._stop_event_monitor(sess)
+        sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
+        sess.interface.destroy_intr_chan.assert_called_once()
+
 
     def test_fire_event_then_wait_on_event(self, lib_and_session):
         """Simulate an SRQ by calling _fire_event on a mocked session."""


### PR DESCRIPTION
On not fully compliant VXI-11 devices (not supporting the interrupt channel), the pyvisa-py code logs exceptions on high log level on connection close. There are some devices out there that fall in this category.
~This PR lowers the log level of those logs, and removes a redundant call to the code that writes those logs.~
This PR removes the calls to the potentially unsupported interrupt channel shutdown procedures if the interrupt channel was not set up in the place. If the channel was set up (and therefore the interrupt procedures are supported), the behaviour is as before. 

- [x] Closes #609 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests. No real change, just removed logs and redundant function call.
- [x] Documented in docs/ as appropriate. Was not documented to start with.
- [x] Added an entry to the CHANGES file
