### PR TITLE
[vxi-11] read function bug corrections 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,10 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Corrected timeout caused by when response length is an exact multiple of chunk_size
+- Read function termination overhaul:
+  Corrected timeout in read when response length is an exact multiple
+  of chunk_size, implemented read count boundary checks, completed termination
+  character detection, allowed use of suppress_end_en, corrected timeout handling.
   Closes #608 PR #612
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down,

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,10 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
+- Corrected timeout caused by when response length is an exact multiple of chunk_size
+  Closes #608 PR #612
+- Removed SRQ server shutdown if the server was already shut down,
+  reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.
   It is not standard behaviour, may confuse instruments, and does not
   cache the SRQ bit as would be required. Closes #603 PR #606
@@ -13,11 +16,11 @@ PyVISA-py Changelog
   (self-pipe trick on recv_into), enabling cross-thread I/O cancellation
   without destroying the session. Also handle HiSLIP Interrupted messages
   in the receive path. Closes #566
-- Fixed VXI-11 read timeouthandling. When reads were splitdown into multiple read 
-  chunks the timeout value for each chunk was calculated wrongly. This resulted in 
+- Fixed VXI-11 read timeout handling. When reads were split down into multiple read
+  chunks the timeout value for each chunk was calculated wrongly. This resulted in
   very high timeout values which had to be set.
-  A second addressed issue is that timeout values never decrement to 0. A timeout value 
-  of 0 is undefined in VXI-11 standard. It can mean "timeout immediately if no data 
+  A second addressed issue is that timeout values never decrement to 0. A timeout value
+  of 0 is undefined in VXI-11 standard. It can mean "timeout immediately if no data
   is in buffer" or "block permanently until transfer is finished".
 - Implement the VISA event subsystem for VXI-11 (TCPIP::INSTR) resources:
   `viEnableEvent`, `viDisableEvent`, `viDiscardEvents`, `viWaitOnEvent`,
@@ -26,7 +29,7 @@ PyVISA-py Changelog
   (`install_handler`) delivery. A daemon thread runs an ONC RPC TCP interrupt
   server to receive VXI-11 `DEVICE_INTR_SRQ` callbacks. This also fixes the
   `create_intr_chan` XDR packer in `protocols/vxi11.py`.
-  Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577 
+  Other transports (GPIB, USBTMC, HiSLIP, Serial) remain unsupported for now. PR #577
 - Pass termchar information to USBTMC devices when reading PR #598
 - Properly configure termchar on GPIB devices. This fix timeout issues for old GPIB devices which do not signal EOI PR #599
 - Clean up GPIB calls to the ib*() routines, by using symbolic definitions

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Read function termination overhaul:
+- VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple
   of chunk_size, implemented read count boundary checks, completed termination
   character detection, allowed use of suppress_end_en, corrected timeout handling.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -741,7 +741,7 @@ class TCPIPInstrVxi11(Session):
         # Get the timeout as cleaned up by the upper layers
         timeout = self._io_timeout
 
-        # See if a timeout was really set. 
+        # See if a timeout was really set.
         # if self.timeout is None, the given timeout was VI_TMO_INFINITE
         # This lookup method is also slightly convoluted because the unit test scripts
         # may not have set this correctly.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -752,7 +752,10 @@ class TCPIPInstrVxi11(Session):
             count -= len(data)
 
             if count <= 0:
-                status = StatusCode.success_max_count_read
+                if reason & end_reason:
+                    status = StatusCode.success
+                else:
+                    status = StatusCode.success_max_count_read
                 break
 
             chunk_length = min(count, chunk_length)

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -738,9 +738,13 @@ class TCPIPInstrVxi11(Session):
         read_fun = self.interface.device_read
         status = StatusCode.success
 
-        timeout = self._io_timeout  # this is derived from from self.timeout
-        # See if a timeout was set. This is derived from self.timeout, but slightly
-        # convoluted because the unit test scripts may not have set this correctly.
+        # get the timeout as cleaned up by the upper layers
+        timeout = self._io_timeout
+        
+        # See if a timeout was really set. This is done by looking at the timeout
+        # that was given to the interface. If it is None, then there is no timeout. 
+        # This lookup method is also slightly convoluted because the unit test scripts
+        # may not have set this correctly.
         finite_timeout = getattr(self, "timeout", None) is not None
         start_time = time.time()
         while reason & stop_reason == 0:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -759,10 +759,13 @@ class TCPIPInstrVxi11(Session):
             # Calculate timeout for current chunk.
             # Limit the minimum timeout to 10ms, because 0 is undefined
             # according to VXI-11 spec (done also by Visas)
-            elapsed_ms = int((time.time() - start_time) * 1000)
-            remaining_timeout = timeout - elapsed_ms
-            if finite_timeout and remaining_timeout <= 0:
-                return bytes(read_data), StatusCode.error_timeout
+            if finite_timeout:
+                elapsed_ms = int((time.time() - start_time) * 1000)
+                remaining_timeout = timeout - elapsed_ms
+                if remaining_timeout <= 0:
+                    return bytes(read_data), StatusCode.error_timeout
+            else:
+                remaining_timeout = 2**32 - 1  # VI_TMO_INFINITE
             chunk_timeout = max(10, remaining_timeout)
             error, reason, data = read_fun(
                 self.link,

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -740,9 +740,9 @@ class TCPIPInstrVxi11(Session):
         status = StatusCode.success
 
         timeout = self._io_timeout  # this is derived from from self.timeout
-        # See if a timeout was set. This is derived from self.timeout, but slightly 
-        # convoluted because the unit test scripts may not have set this correctly.      
-        finite_timeout = getattr(self, "timeout", None) is not None  
+        # See if a timeout was set. This is derived from self.timeout, but slightly
+        # convoluted because the unit test scripts may not have set this correctly.
+        finite_timeout = getattr(self, "timeout", None) is not None
         start_time = time.time()
         while reason & stop_reason == 0:
             # Decrease timeout so that the total timeout does not get larger

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -744,7 +744,7 @@ class TCPIPInstrVxi11(Session):
         # See if a timeout was really set.
         # if self.timeout is None, the given timeout was VI_TMO_INFINITE
         finite_timeout = self.timeout is not None
-        
+
         start_time = time.time()
         while reason & stop_reason == 0:
             # Decrease timeout so that the total timeout does not get larger

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -743,9 +743,8 @@ class TCPIPInstrVxi11(Session):
 
         # See if a timeout was really set.
         # if self.timeout is None, the given timeout was VI_TMO_INFINITE
-        # This lookup method is also slightly convoluted because the unit test scripts
-        # may not have set this correctly.
-        finite_timeout = getattr(self, "timeout", None) is not None
+        finite_timeout = self.timeout is not None
+        
         start_time = time.time()
         while reason & stop_reason == 0:
             # Decrease timeout so that the total timeout does not get larger

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -740,9 +740,9 @@ class TCPIPInstrVxi11(Session):
 
         # get the timeout as cleaned up by the upper layers
         timeout = self._io_timeout
-        
+
         # See if a timeout was really set. This is done by looking at the timeout
-        # that was given to the interface. If it is None, then there is no timeout. 
+        # that was given to the interface. If it is None, then there is no timeout.
         # This lookup method is also slightly convoluted because the unit test scripts
         # may not have set this correctly.
         finite_timeout = getattr(self, "timeout", None) is not None

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -765,7 +765,7 @@ class TCPIPInstrVxi11(Session):
                 if remaining_timeout <= 0:
                     return bytes(read_data), StatusCode.error_timeout
             else:
-                remaining_timeout = 2**32 - 1  # VI_TMO_INFINITE
+                remaining_timeout = constants.VI_TMO_INFINITE  # This is 2**32 - 1
             chunk_timeout = max(10, remaining_timeout)
             error, reason, data = read_fun(
                 self.link,
@@ -1027,15 +1027,15 @@ class TCPIPInstrVxi11(Session):
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
         """Sets timeout calculated value from python way to VI_ way"""
+        # value is in milliseconds,
+        # and can be VI_TMO_INFINITE (2**32 - 1) or VI_TMO_IMMEDIATE (0)
+        self._io_timeout = value
         if value == constants.VI_TMO_INFINITE:
             self.timeout = None
-            self._io_timeout = 2**32 - 1
         elif value == constants.VI_TMO_IMMEDIATE:
             self.timeout = 0
-            self._io_timeout = 0
         else:
             self.timeout = value / 1000.0
-            self._io_timeout = int(self.timeout * 1000)
         return StatusCode.success
 
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -738,11 +738,11 @@ class TCPIPInstrVxi11(Session):
         read_fun = self.interface.device_read
         status = StatusCode.success
 
-        # get the timeout as cleaned up by the upper layers
+        # Get the timeout as cleaned up by the upper layers
         timeout = self._io_timeout
 
-        # See if a timeout was really set. This is done by looking at the timeout
-        # that was given to the interface. If it is None, then there is no timeout.
+        # See if a timeout was really set. 
+        # if self.timeout is None, the given timeout was VI_TMO_INFINITE
         # This lookup method is also slightly convoluted because the unit test scripts
         # may not have set this correctly.
         finite_timeout = getattr(self, "timeout", None) is not None

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -568,7 +568,7 @@ class TCPIPInstrVxi11(Session):
         self.attrs[ResourceAttribute.tcpip_address] = self.parsed.host_address
         self.attrs[ResourceAttribute.tcpip_hostname] = ""
         self.attrs[ResourceAttribute.tcpip_device_name] = self.parsed.lan_device_name
-        for name in ("SEND_END_EN", "TERMCHAR", "TERMCHAR_EN"):
+        for name in ("SEND_END_EN", "TERMCHAR", "TERMCHAR_EN", "SUPPRESS_END_EN"):
             attribute = getattr(constants, "VI_ATTR_" + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
@@ -687,6 +687,15 @@ class TCPIPInstrVxi11(Session):
             except Exception:
                 pass
 
+    def _read_status_from_reason(
+        self, reason: int, suppress_end_en: bool
+    ) -> StatusCode:
+        if reason & vxi11.RX_CHR:
+            return StatusCode.success_termination_character_read
+        if reason & vxi11.RX_END and not suppress_end_en:
+            return StatusCode.success
+        return StatusCode.success_max_count_read
+
     def read(self, count: int) -> Tuple[bytes, StatusCode]:
         """Reads data from device or interface synchronously.
 
@@ -705,10 +714,12 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
-        if count < self.max_recv_size:
-            chunk_length = count
-        else:
-            chunk_length = self.max_recv_size
+        if count < 0:
+            return b"", StatusCode.error_invalid_parameter
+        if count == 0:
+            return b"", StatusCode.success_max_count_read
+
+        chunk_length = min(count, self.max_recv_size)
 
         if self.get_attribute(ResourceAttribute.termchar_enabled)[0]:
             term_char, _ = self.get_attribute(ResourceAttribute.termchar)
@@ -716,24 +727,35 @@ class TCPIPInstrVxi11(Session):
         else:
             term_char = flags = 0
 
+        suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
+
         read_data = bytearray()
         reason = 0
-        # Stop on end of message or when a termination character has been
-        # encountered.
-        end_reason = vxi11.RX_END | vxi11.RX_CHR
+        # RX_CHR always stops the read. RX_END only stops when suppress_end_en
+        # is disabled.
+        stop_reason = vxi11.RX_CHR
+        if not suppress_end_en:
+            stop_reason |= vxi11.RX_END
         read_fun = self.interface.device_read
         status = StatusCode.success
 
-        timeout = self._io_timeout
+        timeout = self._io_timeout  # this is derived from from self.timeout
+        # See if a timeout was set. This is derived from self.timeout, but slightly 
+        # convoluted because the unit test scripts may not have set this correctly.      
+        finite_timeout = getattr(self, "timeout", None) is not None  
         start_time = time.time()
-        while reason & end_reason == 0:
+        while reason & stop_reason == 0:
             # Decrease timeout so that the total timeout does not get larger
             # than the specified timeout.
 
             # Calculate timeout for current chunk.
             # Limit the minimum timeout to 10ms, because 0 is undefined
             # according to VXI-11 spec (done also by Visas)
-            chunk_timeout = max(10, timeout - int((time.time() - start_time) * 1000))
+            elapsed_ms = int((time.time() - start_time) * 1000)
+            remaining_timeout = timeout - elapsed_ms
+            if finite_timeout and remaining_timeout <= 0:
+                return bytes(read_data), StatusCode.error_timeout
+            chunk_timeout = max(10, remaining_timeout)
             error, reason, data = read_fun(
                 self.link,
                 chunk_length,
@@ -752,13 +774,13 @@ class TCPIPInstrVxi11(Session):
             count -= len(data)
 
             if count <= 0:
-                if reason & end_reason:
-                    status = StatusCode.success
-                else:
-                    status = StatusCode.success_max_count_read
+                status = self._read_status_from_reason(reason, suppress_end_en)
                 break
 
             chunk_length = min(count, chunk_length)
+
+        if count > 0 and (reason & stop_reason):
+            status = self._read_status_from_reason(reason, suppress_end_en)
 
         return bytes(read_data), status
 
@@ -830,9 +852,6 @@ class TCPIPInstrVxi11(Session):
         # This is an abuse of the VISA standard
         if attribute == constants.VI_ATTR_TCPIP_KEEPALIVE:
             return self.keepalive, StatusCode.success
-
-        elif attribute == constants.VI_ATTR_SUPPRESS_END_EN:
-            raise NotImplementedError
 
         raise UnknownAttribute(attribute)
 

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -83,7 +83,9 @@ class TestTCPIPInstrVxi11Read:
         assert data == b"ab"
         assert status == StatusCode.error_timeout
 
-    def test_read_with_suppress_end_enabled_returns_max_count_when_count_is_reached(self):
+    def test_read_with_suppress_end_enabled_returns_max_count_when_count_is_reached(
+        self,
+    ):
         sess = self._make_session(termchar_enabled=False, suppress_end_enabled=True)
         sess.interface.device_read.return_value = (0, vxi11.RX_END, b"abc")
 
@@ -94,7 +96,11 @@ class TestTCPIPInstrVxi11Read:
 
     def test_read_with_suppress_end_enabled_still_honors_rx_chr(self):
         sess = self._make_session(termchar_enabled=True, suppress_end_enabled=True)
-        sess.interface.device_read.return_value = (0, vxi11.RX_END | vxi11.RX_CHR, b"abc")
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_END | vxi11.RX_CHR,
+            b"abc",
+        )
 
         data, status = sess.read(10)
 

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -1,0 +1,153 @@
+"""Unit tests for TCPIPInstrVxi11.read status resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pyvisa.constants import ResourceAttribute, StatusCode
+
+from pyvisa_py.protocols import vxi11
+from pyvisa_py.tcpip import TCPIPInstrVxi11
+
+
+class TestTCPIPInstrVxi11Read:
+    def _make_session(
+        self, *, termchar_enabled: bool = False, suppress_end_enabled: bool = False
+    ) -> TCPIPInstrVxi11:
+        sess = object.__new__(TCPIPInstrVxi11)
+        sess.interface = MagicMock()
+        sess.link = 1
+        sess.lock_timeout = 10000
+        sess.max_recv_size = 1024
+        sess._io_timeout = 5000
+        sess.attrs = {
+            ResourceAttribute.termchar_enabled: termchar_enabled,
+            ResourceAttribute.termchar: ord("\n"),
+            ResourceAttribute.suppress_end_enabled: suppress_end_enabled,
+        }
+        return sess
+
+    def test_read_returns_termination_char_status_when_rx_chr_before_count(self):
+        sess = self._make_session(termchar_enabled=True)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_CHR,
+            b"abc",
+        )
+
+        data, status = sess.read(10)
+
+        assert data == b"abc"
+        assert status == StatusCode.success_termination_character_read
+
+    def test_read_with_negative_count_returns_invalid_parameter(self):
+        sess = self._make_session(termchar_enabled=False)
+
+        data, status = sess.read(-1)
+
+        assert data == b""
+        assert status == StatusCode.error_invalid_parameter
+        sess.interface.device_read.assert_not_called()
+
+    def test_read_with_zero_count_returns_success_max_count(self):
+        sess = self._make_session(termchar_enabled=False)
+
+        data, status = sess.read(0)
+
+        assert data == b""
+        assert status == StatusCode.success_max_count_read
+        sess.interface.device_read.assert_not_called()
+
+    def test_read_returns_success_when_rx_end_before_count(self):
+        sess = self._make_session(termchar_enabled=False)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_END,
+            b"abc",
+        )
+
+        data, status = sess.read(10)
+
+        assert data == b"abc"
+        assert status == StatusCode.success
+
+    def test_read_with_suppress_end_enabled_ignores_rx_end(self):
+        sess = self._make_session(termchar_enabled=False, suppress_end_enabled=True)
+        sess.interface.device_read.side_effect = [
+            (0, vxi11.RX_END, b"ab"),
+            (vxi11.ErrorCodes.io_timeout, 0, b""),
+        ]
+
+        data, status = sess.read(10)
+
+        assert data == b"ab"
+        assert status == StatusCode.error_timeout
+
+    def test_read_with_suppress_end_enabled_returns_max_count_when_count_is_reached(self):
+        sess = self._make_session(termchar_enabled=False, suppress_end_enabled=True)
+        sess.interface.device_read.return_value = (0, vxi11.RX_END, b"abc")
+
+        data, status = sess.read(3)
+
+        assert data == b"abc"
+        assert status == StatusCode.success_max_count_read
+
+    def test_read_with_suppress_end_enabled_still_honors_rx_chr(self):
+        sess = self._make_session(termchar_enabled=True, suppress_end_enabled=True)
+        sess.interface.device_read.return_value = (0, vxi11.RX_END | vxi11.RX_CHR, b"abc")
+
+        data, status = sess.read(10)
+
+        assert data == b"abc"
+        assert status == StatusCode.success_termination_character_read
+
+    def test_read_returns_success_max_count_without_end_reason(self):
+        sess = self._make_session(termchar_enabled=False)
+        sess.interface.device_read.return_value = (
+            0,
+            0,
+            b"abcd",
+        )
+
+        data, status = sess.read(4)
+
+        assert data == b"abcd"
+        assert status == StatusCode.success_max_count_read
+
+    def test_read_timeout_returns_partial_data(self):
+        sess = self._make_session(termchar_enabled=False)
+        sess.interface.device_read.side_effect = [
+            (0, 0, b"ab"),
+            (vxi11.ErrorCodes.io_timeout, 0, b""),
+        ]
+
+        data, status = sess.read(10)
+
+        assert data == b"ab"
+        assert status == StatusCode.error_timeout
+
+    def test_read_returns_timeout_when_total_timeout_is_expired(self, monkeypatch):
+        sess = self._make_session(termchar_enabled=False)
+        sess.timeout = 0.001
+        sess._io_timeout = 1
+
+        times = iter([100.0, 100.003])
+        monkeypatch.setattr("pyvisa_py.tcpip.time.time", lambda: next(times))
+
+        data, status = sess.read(10)
+
+        assert data == b""
+        assert status == StatusCode.error_timeout
+        sess.interface.device_read.assert_not_called()
+
+    def test_read_io_error_returns_partial_data(self):
+        sess = self._make_session(termchar_enabled=False)
+        sess.interface.device_read.side_effect = [
+            (0, 0, b"ab"),
+            (vxi11.ErrorCodes.io_error, 0, b""),
+        ]
+
+        data, status = sess.read(10)
+
+        assert data == b"ab"
+        assert status == StatusCode.error_io

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from pyvisa.constants import ResourceAttribute, StatusCode
 from pyvisa_py.protocols import vxi11
 from pyvisa_py.tcpip import TCPIPInstrVxi11
@@ -70,6 +72,40 @@ class TestTCPIPInstrVxi11Read:
 
         assert data == b"abc"
         assert status == StatusCode.success
+
+    @pytest.mark.parametrize("chunk_size", range(1, 11))
+    def test_read_handles_exact_ten_byte_content_for_all_chunk_sizes(
+        self, chunk_size: int
+    ):
+        sess = self._make_session(termchar_enabled=False, suppress_end_enabled=False)
+        sess.max_recv_size = chunk_size
+        content = b"abcdefghij"
+        sess.interface.device_read.side_effect = [
+            (0, 0, content[offset : offset + chunk_size])
+            for offset in range(0, len(content), chunk_size)
+        ]
+
+        data, status = sess.read(len(content))
+
+        assert data == content
+        assert status == StatusCode.success_max_count_read
+
+    @pytest.mark.parametrize("chunk_size", range(1, 11))
+    def test_read_with_suppress_end_enabled_handles_exact_ten_byte_content_for_all_chunk_sizes(
+        self, chunk_size: int
+    ):
+        sess = self._make_session(termchar_enabled=False, suppress_end_enabled=True)
+        sess.max_recv_size = chunk_size
+        content = b"abcdefghij"
+        sess.interface.device_read.side_effect = [
+            (0, vxi11.RX_END, content[offset : offset + chunk_size])
+            for offset in range(0, len(content), chunk_size)
+        ]
+
+        data, status = sess.read(len(content))
+
+        assert data == content
+        assert status == StatusCode.success_max_count_read
 
     def test_read_with_suppress_end_enabled_ignores_rx_end(self):
         sess = self._make_session(termchar_enabled=False, suppress_end_enabled=True)

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -2,7 +2,9 @@
 """Unit tests for TCPIPInstrVxi11.read status resolution."""
 
 from __future__ import annotations
+
 from unittest.mock import MagicMock
+
 from pyvisa.constants import ResourceAttribute, StatusCode
 from pyvisa_py.protocols import vxi11
 from pyvisa_py.tcpip import TCPIPInstrVxi11

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -1,11 +1,9 @@
+# -*- coding: utf-8 -*-
 """Unit tests for TCPIPInstrVxi11.read status resolution."""
 
 from __future__ import annotations
-
 from unittest.mock import MagicMock
-
 from pyvisa.constants import ResourceAttribute, StatusCode
-
 from pyvisa_py.protocols import vxi11
 from pyvisa_py.tcpip import TCPIPInstrVxi11
 

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -22,6 +22,7 @@ class TestTCPIPInstrVxi11Read:
         sess.lock_timeout = 10000
         sess.max_recv_size = 1024
         sess._io_timeout = 5000
+        sess.timeout = 5
         sess.attrs = {
             ResourceAttribute.termchar_enabled: termchar_enabled,
             ResourceAttribute.termchar: ord("\n"),


### PR DESCRIPTION
**Why**

* On certain `inst.chunk_size` values in relation to the content size, a read falls in timeout. This is corrected.
* Read function:
    * return values (status codes) were incomplete. It is now compliant, and can return all 3 non-error possibilities: `success`, `success_termination_character_read`, `success_max_count_read`, all while taking into account `VI_ATTR_SUPPRESS_END_EN`
    * count boundary check (was absent)
    * timeout handling (was incomplete)
    * zero length handling (was incomplete)

**Tasks**

- [x] Closes #608 (and corrected some spacing problems and removed some trailing spaces from CHANGES.md)
- [ ] Executed ``black . && isort -c . && flake8`` with no errors. -> Is this still valid? It seems outdated.
- [x] The change is fully covered by automated unit tests.  Well, not really. Could do it, but will take a lot of time as the framework for this type of tests is lacking in my setup. (need the keysight tools, likely have to find a Windows machine....) But see below for a test setup.
- [ ] Documented in docs/ as appropriate. -> There was no doc of this bug. I might create another PR to document the gaps between pyvisa-py and the 'de facto standard' NI-Visa in more detail.
- [x] Added an entry to the CHANGES file
