### PR TITLE
remove return on device_intr_srq

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.
   It is not standard behaviour, may confuse instruments, and does not

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -468,7 +468,7 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                     call += leftover
 
                 self.handle(call)
-                # a reply to this call is not expected nor recommended for DEVICE_INTR_SRQ. 
+                # a reply to this call is not expected nor recommended for DEVICE_INTR_SRQ.
         except Exception:
             LOGGER.exception("Error handling TCP SRQ connection")
 

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -467,10 +467,8 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                         return
                     call += leftover
 
-                reply = self.handle(call)
-                if reply is not None:
-                    reply_frag = struct.pack(">I", 0x80000000 | len(reply)) + reply
-                    conn.sendall(reply_frag)
+                self.handle(call)
+                # a reply to this call is not expected nor recommended for DEVICE_INTR_SRQ. 
         except Exception:
             LOGGER.exception("Error handling TCP SRQ connection")
 


### PR DESCRIPTION
- [x] Closes #614
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests. This was not subject to a test, and this is code removal.
- [x] Documented in docs/ as appropriate. Was not documented.
- [x] Added an entry to the CHANGES file
