### PR TITLE
Treat open_timeout=0 as "use the default" in TCP transports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,13 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- Treat an ``open_timeout`` of 0 (``VI_TMO_IMMEDIATE``) as "use the default"
+  rather than "give up immediately" across the TCP transports. Since
+  ``ResourceManager.open_resource`` passes 0 whenever the caller supplies no
+  ``open_timeout``, VXI-11 opens were allowing 100 ms for the entire TCP
+  handshake and reporting anything slower as ``VI_ERROR_RSRC_NFOUND``. HiSLIP
+  now applies ``open_timeout`` to its connections as the other TCP transports
+  do, rather than ignoring it. Closes #578
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.

--- a/CHANGES
+++ b/CHANGES
@@ -4,13 +4,18 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Treat an ``open_timeout`` of 0 (``VI_TMO_IMMEDIATE``) as "use the default"
-  rather than "give up immediately" across the TCP transports. Since
+- Apply ``open_timeout`` to the connection attempt across all the TCP
+  transports, as VPP-4.3 PERMISSION 4.3.2 allows. An ``open_timeout`` of 0
+  (``VI_TMO_IMMEDIATE``) now means 2000 ms, which is what VPP-4.3
+  RECOMMENDATION 4.3.3 asks of an implementation that does this.
   ``ResourceManager.open_resource`` passes 0 whenever the caller supplies no
-  ``open_timeout``, VXI-11 opens were allowing 100 ms for the entire TCP
+  ``open_timeout``, so VXI-11 opens had been allowing 100 ms for the whole TCP
   handshake and reporting anything slower as ``VI_ERROR_RSRC_NFOUND``. HiSLIP
-  now applies ``open_timeout`` to its connections as the other TCP transports
-  do, rather than ignoring it. Closes #578
+  now honors ``open_timeout`` rather than ignoring it. That same 2000 ms is the
+  new default everywhere, replacing 5 s for VXI-11 and HiSLIP and 10 s for
+  ``TCPIP::SOCKET``. The trade-off is that ``VI_TMO_IMMEDIATE`` can no longer
+  mean "never wait on a lock". Use the session's ``lock_timeout`` for that. See
+  the FAQ. Closes #578
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -144,6 +144,44 @@ In the case of the DM3068, the VXI-11 lock timeout must be set to zero:
     >>> # can now communicate successfully with the DM3068
 
 
+What does ``open_timeout`` control?
+-----------------------------------
+
+For the TCP transports (``TCPIP::INSTR``, both VXI-11 and HiSLIP, and
+``TCPIP::SOCKET``), ``open_timeout`` bounds how long PyVISA-py will spend
+establishing the connection::
+
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> # allow 10 s to reach an instrument across a slow link
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000)
+
+If you do not pass one, the connection attempt is given 2000 ms.  An
+``open_timeout`` of 0 selects that same default rather than meaning "give up
+immediately", since ``ResourceManager.open_resource`` passes 0 whenever you
+omit the argument.
+
+.. note::
+
+    **Portability:** what ``open_timeout`` does is seemingly inconsistent
+    across VISA implementations.  It is the ``viOpen`` timeout parameter, which
+    VPP-4.3 section 4.3.3 defines as the time to wait for a lock.  VPP-4.3
+    PERMISSION 4.3.2 also allows using it for the open itself, which is what
+    PyVISA-py does, but an implementation is free not to.  An ``open_timeout``
+    chosen for a slow link may therefore have no effect elsewhere.
+
+    The 2000 ms comes from VPP-4.3 RECOMMENDATION 4.3.3:
+
+        If the value of the timeout parameter to viOpen is 0 and a VISA
+        implementation uses the timeout when opening the resource, the
+        implementation should behave as if the timeout parameter is the VISA
+        default timeout value of 2000 milliseconds.
+
+    The trade-off is that ``VI_TMO_IMMEDIATE`` can no longer request "never
+    wait on a lock".  Set ``lock_timeout`` on the session for that, as in the
+    DM3068 example above.
+
+
 .. _PySerial: https://pythonhosted.org/pyserial/
 .. _PyVISA: http://pyvisa.readthedocs.org/
 .. _PyUSB: https://github.com/pyusb/pyusb

--- a/pyvisa_py/common.py
+++ b/pyvisa_py/common.py
@@ -68,13 +68,6 @@ def connect_timeout(open_timeout: Optional[float]) -> float:
         implementation should behave as if the timeout parameter is the VISA
         default timeout value of 2000 milliseconds.
 
-    That is the common path, not an edge case. ``ResourceManager.open_resource``
-    passes 0 whenever the caller supplies no ``open_timeout``. A literal 0 would
-    leave no time for the TCP handshake and fail every open with
-    ``VI_ERROR_RSRC_NFOUND``.
-
-    The cost is that ``VI_TMO_IMMEDIATE`` can no longer mean "never wait on a
-    lock". Use the session's ``lock_timeout`` for that.
     """
     return DEFAULT_OPEN_TIMEOUT / 1000 if not open_timeout else open_timeout / 1000
 

--- a/pyvisa_py/common.py
+++ b/pyvisa_py/common.py
@@ -40,16 +40,43 @@ def int_to_byte(val):
     return val.to_bytes(1, "big")
 
 
-def connect_timeout(open_timeout: Optional[float], default: float) -> float:
-    """Seconds to allow for connecting, from a VISA ``open_timeout``.
+#: Milliseconds allowed for establishing a connection when the caller does not
+#: ask for something else. See :func:`connect_timeout`.
+DEFAULT_OPEN_TIMEOUT = 2000.0
 
-    ``open_timeout`` is in milliseconds. Both ``None`` (unset) and ``0``
-    (``VI_TMO_IMMEDIATE``, which ``ResourceManager.open_resource`` passes
-    whenever the caller does not supply one) mean "use ``default``". Taking a 0
-    literally leaves no time for the TCP handshake, which turns a cold open into
-    a spurious ``VI_ERROR_RSRC_NFOUND``.
+
+def connect_timeout(open_timeout: Optional[float]) -> float:
+    """Seconds to allow for connecting, from a VISA ``open_timeout`` in ms.
+
+    ``None`` (unset) and ``0`` (``VI_TMO_IMMEDIATE``) both mean "use
+    :data:`DEFAULT_OPEN_TIMEOUT`".
+
+    VPP-4.3 section 4.3.3 defines the ``viOpen`` timeout parameter, which
+    PyVISA exposes as ``open_timeout``, as the time to wait for a lock. But
+    VPP-4.3 PERMISSION 4.3.2 also allows using it for the open itself:
+
+        A VISA implementation MAY use the timeout parameter when opening the
+        resource, regardless of whether the VI_EXCLUSIVE_LOCK flag is
+        specified.
+
+    PyVISA-py does that. For the TCP transports ``open_timeout`` bounds the
+    connection attempt, which lets a slow link be reached without raising the
+    I/O timeout too. VPP-4.3 RECOMMENDATION 4.3.3 then says how to read a 0:
+
+        If the value of the timeout parameter to viOpen is 0 and a VISA
+        implementation uses the timeout when opening the resource, the
+        implementation should behave as if the timeout parameter is the VISA
+        default timeout value of 2000 milliseconds.
+
+    That is the common path, not an edge case. ``ResourceManager.open_resource``
+    passes 0 whenever the caller supplies no ``open_timeout``. A literal 0 would
+    leave no time for the TCP handshake and fail every open with
+    ``VI_ERROR_RSRC_NFOUND``.
+
+    The cost is that ``VI_TMO_IMMEDIATE`` can no longer mean "never wait on a
+    lock". Use the session's ``lock_timeout`` for that.
     """
-    return default if not open_timeout else 1e-3 * open_timeout
+    return DEFAULT_OPEN_TIMEOUT / 1000 if not open_timeout else open_timeout / 1000
 
 
 # TODO(anyone): This is copypasta from `pyvisa-sim` project - find a way to

--- a/pyvisa_py/common.py
+++ b/pyvisa_py/common.py
@@ -40,6 +40,18 @@ def int_to_byte(val):
     return val.to_bytes(1, "big")
 
 
+def connect_timeout(open_timeout: Optional[float], default: float) -> float:
+    """Seconds to allow for connecting, from a VISA ``open_timeout``.
+
+    ``open_timeout`` is in milliseconds. Both ``None`` (unset) and ``0``
+    (``VI_TMO_IMMEDIATE``, which ``ResourceManager.open_resource`` passes
+    whenever the caller does not supply one) mean "use ``default``". Taking a 0
+    literally leaves no time for the TCP handshake, which turns a cold open into
+    a spurious ``VI_ERROR_RSRC_NFOUND``.
+    """
+    return default if not open_timeout else 1e-3 * open_timeout
+
+
 # TODO(anyone): This is copypasta from `pyvisa-sim` project - find a way to
 #   reduce duplication, probably in that project instead of here.
 def _create_bitmask(bits: int) -> int:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -15,9 +15,6 @@ from pyvisa_py.common import BytesBuffer, MutableBytesBuffer, connect_timeout
 
 PORT = 4880
 
-#: Seconds allowed for the TCP connection when no ``open_timeout`` is given.
-DEFAULT_CONNECT_TIMEOUT = 5.0
-
 MESSAGETYPE_STR: Dict[int, str] = {
     0: "Initialize",
     1: "InitializeResponse",
@@ -465,7 +462,7 @@ class Instrument:
         timeout = timeout or 5.0
         # ``open_timeout`` bounds the connection attempt on both channels, as it
         # does for the other TCP transports.
-        connecting = connect_timeout(open_timeout, DEFAULT_CONNECT_TIMEOUT)
+        connecting = connect_timeout(open_timeout)
 
         # open the synchronous socket and send an initialize packet
         raw_sync = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -11,9 +11,12 @@ import threading
 import time
 from typing import Dict, Optional, Tuple
 
-from pyvisa_py.common import BytesBuffer, MutableBytesBuffer
+from pyvisa_py.common import BytesBuffer, MutableBytesBuffer, connect_timeout
 
 PORT = 4880
+
+#: Seconds allowed for the TCP connection when no ``open_timeout`` is given.
+DEFAULT_CONNECT_TIMEOUT = 5.0
 
 MESSAGETYPE_STR: Dict[int, str] = {
     0: "Initialize",
@@ -448,7 +451,7 @@ class Instrument:
     def __init__(
         self,
         ip_addr: str,
-        open_timeout: Optional[float] = 0.0,
+        open_timeout: Optional[float] = None,
         timeout: Optional[float] = None,
         port: int = PORT,
         sub_address: str = "hislip0",
@@ -460,13 +463,13 @@ class Instrument:
         #     S->C: AsyncInitializeResponse
 
         timeout = timeout or 5.0
+        # ``open_timeout`` bounds the connection attempt on both channels, as it
+        # does for the other TCP transports.
+        connecting = connect_timeout(open_timeout, DEFAULT_CONNECT_TIMEOUT)
 
         # open the synchronous socket and send an initialize packet
         raw_sync = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # The VISA spec does not allow to tune the socket timeout when opening
-        # a connection. ``open_timeout`` only applies to attempt to acquire a
-        # lock.
-        raw_sync.settimeout(5.0)
+        raw_sync.settimeout(connecting)
         raw_sync.connect((ip_addr, port))
         raw_sync.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
@@ -483,8 +486,8 @@ class Instrument:
 
         # open the asynchronous socket and send an initialize packet
         self._async = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._async.settimeout(connecting)
         self._async.connect((ip_addr, port))
-        self._async.settimeout(5.0)
         self._async.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self._async_init = self.async_initialize(session_id=init.session_id)
         # We set the user timeout once we managed to initialize the connection.

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -25,8 +25,11 @@ import struct
 import sys
 import time
 
-from ..common import LOGGER
+from ..common import LOGGER, connect_timeout
 from . import xdrlib
+
+#: Seconds allowed for the TCP connection when no ``open_timeout`` is given.
+DEFAULT_CONNECT_TIMEOUT = 5.0
 
 #: Version of the protocol
 RPCVERSION = 2
@@ -450,8 +453,7 @@ class RawTCPClient(Client):
 
     def __init__(self, host, prog, vers, port, open_timeout=5000):
         Client.__init__(self, host, prog, vers, port)
-        open_timeout = open_timeout if open_timeout is not None else 5000
-        self.connect(1e-3 * open_timeout)
+        self.connect(connect_timeout(open_timeout, DEFAULT_CONNECT_TIMEOUT))
         # self.timeout defaults higher than the default 2 second VISA timeout,
         # ensuring that VISA timeouts take precedence.
         self.timeout = 4.0

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -28,9 +28,6 @@ import time
 from ..common import LOGGER, connect_timeout
 from . import xdrlib
 
-#: Seconds allowed for the TCP connection when no ``open_timeout`` is given.
-DEFAULT_CONNECT_TIMEOUT = 5.0
-
 #: Version of the protocol
 RPCVERSION = 2
 
@@ -451,9 +448,9 @@ def _connect(sock, host, port, timeout=0):
 class RawTCPClient(Client):
     """Client using TCP to a specific port."""
 
-    def __init__(self, host, prog, vers, port, open_timeout=5000):
+    def __init__(self, host, prog, vers, port, open_timeout=None):
         Client.__init__(self, host, prog, vers, port)
-        self.connect(connect_timeout(open_timeout, DEFAULT_CONNECT_TIMEOUT))
+        self.connect(connect_timeout(open_timeout))
         # self.timeout defaults higher than the default 2 second VISA timeout,
         # ensuring that VISA timeouts take precedence.
         self.timeout = 4.0
@@ -801,7 +798,7 @@ class PartialPortMapperClient(object):
 
 
 class TCPPortMapperClient(PartialPortMapperClient, RawTCPClient):
-    def __init__(self, host, open_timeout=5000):
+    def __init__(self, host, open_timeout=None):
         RawTCPClient.__init__(self, host, PMAP_PROG, PMAP_VERS, PMAP_PORT, open_timeout)
         PartialPortMapperClient.__init__(self)
 
@@ -821,7 +818,7 @@ class BroadcastUDPPortMapperClient(PartialPortMapperClient, RawBroadcastUDPClien
 class TCPClient(RawTCPClient):
     """A TCP Client that find their server through the Port mapper"""
 
-    def __init__(self, host, prog, vers, open_timeout=5000):
+    def __init__(self, host, prog, vers, open_timeout=None):
         pmap = TCPPortMapperClient(host, open_timeout)
         port = pmap.get_port((prog, vers, IPPROTO_TCP, 0))
         pmap.close()

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -22,7 +22,7 @@ from pyvisa import attributes, constants, errors, rname
 from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
 from pyvisa.typing import VISAJobID
 
-from .common import LOGGER, int_to_byte
+from .common import LOGGER, connect_timeout, int_to_byte
 from .protocols import hislip, rpc, vxi11
 from .sessions import OpenError, Session, UnknownAttribute, VISARMSession
 
@@ -143,11 +143,9 @@ class TCPIPInstrHiSLIP(Session):
         try:
             self.interface = hislip.Instrument(
                 self.parsed.host_address,
-                open_timeout=(
-                    self.open_timeout * 1000.0
-                    if self.open_timeout is not None
-                    else self.open_timeout
-                ),
+                # ``open_timeout`` is already in milliseconds, which is what
+                # hislip.Instrument expects.
+                open_timeout=self.open_timeout,
                 timeout=self.timeout,
                 port=port,
                 sub_address=sub_address,
@@ -1295,7 +1293,7 @@ class TCPIPSocketSession(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def _connect(self) -> StatusCode:
-        timeout = self.open_timeout / 1000.0 if self.open_timeout else 10.0
+        timeout = connect_timeout(self.open_timeout, 10.0)
         try:
             self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.interface.setblocking(False)

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -430,7 +430,7 @@ class Vxi11CoreClient(vxi11.CoreClient):
     """
 
     def __init__(
-        self, host: str, port: Optional[int], open_timeout: Optional[int] = 5000
+        self, host: str, port: Optional[int], open_timeout: Optional[int] = None
     ) -> None:
         self._lock = threading.Lock()
         self.packer = vxi11.Vxi11Packer()
@@ -1293,7 +1293,7 @@ class TCPIPSocketSession(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
     def _connect(self) -> StatusCode:
-        timeout = connect_timeout(self.open_timeout, 10.0)
+        timeout = connect_timeout(self.open_timeout)
         try:
             self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.interface.setblocking(False)

--- a/pyvisa_py/testsuite/test_open_timeout.py
+++ b/pyvisa_py/testsuite/test_open_timeout.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Test that a default (0) open_timeout does not collapse connect deadlines.
+
+``ResourceManager.open_resource`` passes ``VI_TMO_IMMEDIATE`` (0) when the
+caller supplies no ``open_timeout``, so every transport has to read a 0 as
+"use the default" rather than "give up immediately".
+
+"""
+
+import pytest
+
+from pyvisa_py.common import connect_timeout
+from pyvisa_py.protocols import hislip, rpc
+
+
+@pytest.mark.parametrize(
+    "open_timeout, expected",
+    [(None, 5.0), (0, 5.0), (0.0, 5.0), (1234, 1.234)],
+)
+def test_connect_timeout(open_timeout, expected):
+    assert connect_timeout(open_timeout, 5.0) == expected
+
+
+@pytest.mark.parametrize("open_timeout, expected", [(None, 5.0), (0, 5.0), (2500, 2.5)])
+def test_raw_tcp_client_connect_deadline(monkeypatch, open_timeout, expected):
+    """RawTCPClient gives the handshake the default deadline, not 0 seconds."""
+    seen = []
+
+    def fake_connect(sock, host, port, timeout=0):
+        seen.append(timeout)
+        return True
+
+    monkeypatch.setattr(rpc, "_connect", fake_connect)
+    rpc.RawTCPClient("localhost", 1, 1, 1234, open_timeout)
+    assert seen == [expected]
+
+
+@pytest.mark.parametrize("open_timeout, expected", [(None, 5.0), (0, 5.0), (2500, 2.5)])
+def test_hislip_connect_deadline(monkeypatch, open_timeout, expected):
+    """hislip.Instrument applies open_timeout to both channel connections."""
+    seen = []
+
+    class FakeSocket:
+        def settimeout(self, value):
+            seen.append(value)
+
+        def connect(self, address):
+            raise _Connected()
+
+        def setsockopt(self, *args):
+            pass
+
+    class _Connected(Exception):
+        pass
+
+    monkeypatch.setattr(hislip.socket, "socket", lambda *a, **kw: FakeSocket())
+    with pytest.raises(_Connected):
+        hislip.Instrument("localhost", open_timeout=open_timeout)
+    # The deadline is set before connect() is attempted.
+    assert seen == [expected]

--- a/pyvisa_py/testsuite/test_open_timeout.py
+++ b/pyvisa_py/testsuite/test_open_timeout.py
@@ -2,26 +2,31 @@
 """Test that a default (0) open_timeout does not collapse connect deadlines.
 
 ``ResourceManager.open_resource`` passes ``VI_TMO_IMMEDIATE`` (0) when the
-caller supplies no ``open_timeout``, so every transport has to read a 0 as
-"use the default" rather than "give up immediately".
+caller supplies no ``open_timeout``. Every transport has to read that 0 as
+2000 ms, per VPP-4.3 RECOMMENDATION 4.3.3, not as "give up immediately".
 
 """
 
 import pytest
 
-from pyvisa_py.common import connect_timeout
+from pyvisa_py.common import DEFAULT_OPEN_TIMEOUT, connect_timeout
 from pyvisa_py.protocols import hislip, rpc
 
 
 @pytest.mark.parametrize(
     "open_timeout, expected",
-    [(None, 5.0), (0, 5.0), (0.0, 5.0), (1234, 1.234)],
+    [(None, 2.0), (0, 2.0), (0.0, 2.0), (1234, 1.234)],
 )
 def test_connect_timeout(open_timeout, expected):
-    assert connect_timeout(open_timeout, 5.0) == expected
+    assert connect_timeout(open_timeout) == expected
 
 
-@pytest.mark.parametrize("open_timeout, expected", [(None, 5.0), (0, 5.0), (2500, 2.5)])
+def test_default_open_timeout_matches_spec():
+    """VPP-4.3 RECOMMENDATION 4.3.3 names 2000 ms."""
+    assert DEFAULT_OPEN_TIMEOUT == 2000.0
+
+
+@pytest.mark.parametrize("open_timeout, expected", [(None, 2.0), (0, 2.0), (2500, 2.5)])
 def test_raw_tcp_client_connect_deadline(monkeypatch, open_timeout, expected):
     """RawTCPClient gives the handshake the default deadline, not 0 seconds."""
     seen = []
@@ -35,7 +40,7 @@ def test_raw_tcp_client_connect_deadline(monkeypatch, open_timeout, expected):
     assert seen == [expected]
 
 
-@pytest.mark.parametrize("open_timeout, expected", [(None, 5.0), (0, 5.0), (2500, 2.5)])
+@pytest.mark.parametrize("open_timeout, expected", [(None, 2.0), (0, 2.0), (2500, 2.5)])
 def test_hislip_connect_deadline(monkeypatch, open_timeout, expected):
     """hislip.Instrument applies open_timeout to both channel connections."""
     seen = []


### PR DESCRIPTION
ResourceManager.open_resource defaults open_timeout to VI_TMO_IMMEDIATE (0), not None. But when choosing to use the default, the code checks if the timeout is not None literally. In RawTCPClient that meant _connect() got a 0 second deadline (which ends up as ~100ms) rather than the default. So any handshake slower than that failed as VI_ERROR_RSRC_NFOUND, it probably works fine generally on localhost but over the network open_timeout is effectively required.

Audit of every transport:

- VXI-11 (TCPIP::INSTR), both the portmapper and explicit-port paths, and the portmapper client itself: all funnel through RawTCPClient. Fixed.
- HiSLIP: accepted open_timeout and ignored it, hardcoding 5 s, while tcpip.py scaled it by 1000 on the way in (it is already milliseconds). Now honored on both the sync and async connections. The async socket also had no deadline at all during connect(), since it set one only afterwards.
- TCPIP::SOCKET (and the Prologix INTFC session that inherits it): was already correct; moved to the shared helper.
- VICP: pyvicp takes no separate open timeout. It derives its connect deadline from the I/O timeout, defaulting to 5 s when that is unset or 0, so the bug cannot reach it.

common.connect_timeout() is now the single place that maps a VISA open_timeout in milliseconds onto a connect deadline in seconds.

I went back and read the history of this functionality in pyvisa-py/pyvisa (may have missed some things) and I _think_ understand that the HiSLIP omission was intentional because of how VPP-4.3 is written - I read @MatthieuDartiailh's NI forum post and the spec itself, and I still (personally) think that the behavior presented in this PR is probably correct, even in light of the spec. In particular, my read of PERMISSION 4.3.2 in VPP-4.3 §4.3.3.2, which states:

> A VISA implementation MAY use the timeout parameter when opening the resource, regardless of
whether the VI_EXCLUSIVE_LOCK flag is specified.

... implies this usage is reasonable.

I'm of course very happy to drop that bit, revert back to a more strict reading of the spec (eg make the VXI-11/tcpip clients behave like hislip), or even just split the difference and just fix the None behavior.

- [x] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

I took that second bullet to mean that I ran the ruff/mypy checks that CI does, since it looks like the codebase migrated a while ago, and black style isnt exactly what we use anymore.

Closes #578

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->
