### PR TITLE
Allow link ID 0 to be used

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Allow link ID 0 to be used. Closes #618 PR #619
+- VXI-11: Allow link ID 0 to be used for SRQ in agreement with the specs
+  and other implementations. Closes #618 PR #619
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- Allow link ID 0 to be used. Closes #618 PR #619
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -493,7 +493,7 @@ class SrqInterruptTCPServer(rpc.TCPServer):
     def _fire_srq(self):
         try:
             # Defensive: session may have been closed while we were spawned
-            if self.session.interface is None or self.session.link == 0:
+            if self.session.interface is None:
                 return
             ctx = EventContext(
                 event_type=constants.EventType.service_request,

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -580,7 +580,6 @@ class TCPIPInstrVxi11(Session):
             LOGGER.error("Error closing VISA link: {}".format(e))
 
         self.interface.close()
-        self.link = 0  # watch out: 0 is still a valid link number, do not consider 0 to be 'closed'
         self.interface = None
 
         return StatusCode.success

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -580,7 +580,7 @@ class TCPIPInstrVxi11(Session):
             LOGGER.error("Error closing VISA link: {}".format(e))
 
         self.interface.close()
-        self.link = 0
+        self.link = 0  # watch out: 0 is still a valid link number, do not consider 0 to be 'closed'
         self.interface = None
 
         return StatusCode.success

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -606,7 +606,7 @@ class TestVxi11SrqFlow:
 
         sess = MagicMock(spec=TCPIPInstrVxi11)
         sess._event_state = EventState()
-        sess.link = 1
+        sess.link = 0  # any number is valid
         sess.interface = MagicMock()
         sess.interface.create_intr_chan.return_value = 0
         sess.interface.device_enable_srq.return_value = 0


### PR DESCRIPTION
- [x] Closes #618 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests. Was not tested before. Removed condition, added comment with alert, and changed test from link=1 to link=0
- [x] Documented in docs/ as appropriate. Was not documented as a limitation
- [x] Added an entry to the CHANGES file
