### PR TITLE
[vxi-11] SRQ handling bug repairs: provoked instrument crash and pyvisa-py crash

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- Fixed crash on DEVICE_ENABLE_SRQ(off). Closes #620 PR #621
 - Removed return packet on device_intr_srq. Closes #614 PR #615
 - Removed SRQ server shutdown if the server was already shut down, reducing potential problems with non compliant devices. Closes #609 PR #610
 - Removed additional read_stb inside VXI-11 (TCPIP::INSTR) SRQ handling.

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- Fixed crash on DEVICE_ENABLE_SRQ(off). Closes #620 PR #621
+- Fixed crash on DEVICE_ENABLE_SRQ(off) and accept malformed SRQ packets. Closes #620 PR #621
 - VXI-11: Allow link ID 0 to be used for SRQ in agreement with the specs
   and other implementations. Closes #618 PR #619
 - Removed return packet on device_intr_srq. Closes #614 PR #615

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -899,7 +899,7 @@ class Server(object):
         self.prog = prog
         self.vers = vers
         self.port = port  # Should normally be 0 for random port
-        self.port = port
+        self.prot = IPPROTO_TCP  # default
         self.addpackers()
 
     def register(self):

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -412,7 +412,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
         self.port = self.sock.getsockname()[1]
         stop_flag = self.session._event_state.stop_flag
         while not stop_flag.is_set():
-            LOGGER.debug("TCP SRQ (%d): Waiting for new connection from instrument", self.port)
+            LOGGER.debug(
+                "TCP SRQ (%d): Waiting for new connection from instrument", self.port
+            )
             try:
                 conn, _addr = self.sock.accept()
             except TimeoutError:
@@ -444,7 +446,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                     # Read record marker (4 bytes)
                     marker = self._recv_all(conn, 4)
                     if marker is None:
-                        LOGGER.debug("TCP SRQ (%d): Connection closed by peer", self.port)
+                        LOGGER.debug(
+                            "TCP SRQ (%d): Connection closed by peer", self.port
+                        )
                         return  # Connection closed by peer
                 except TimeoutError:
                     continue
@@ -474,10 +478,14 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                 self.handle(call)
                 # a reply to this call is not expected nor recommended for DEVICE_INTR_SRQ.
         except Exception:
-            LOGGER.exception("TCP SRQ (%d): Error handling TCP SRQ connection", self.port)
+            LOGGER.exception(
+                "TCP SRQ (%d): Error handling TCP SRQ connection", self.port
+            )
 
     def _recv_all(self, sock, n):
-        LOGGER.debug("TCP SRQ (%d): Receiving %d bytes from TCP SRQ connection", self.port, n)
+        LOGGER.debug(
+            "TCP SRQ (%d): Receiving %d bytes from TCP SRQ connection", self.port, n
+        )
         remaining = n
         data = b""
         while len(data) < n:
@@ -485,23 +493,34 @@ class SrqInterruptTCPServer(rpc.TCPServer):
             # If we already received a partial payload, treat a timeout while waiting for
             # the last 1-4 bytes as a valid short read instead of dropping the SRQ.
             # LOGGER.debug("TCP SRQ (%d): %d out of %d bytes remaining to receive", self.port, remaining, n)
-            
+
             try:
                 chunk = sock.recv(remaining)
             except TimeoutError:
-                LOGGER.debug("TCP SRQ (%d): timeout while receiving %d bytes from TCP SRQ connection", self.port, remaining)
+                LOGGER.debug(
+                    "TCP SRQ (%d): timeout while receiving %d bytes from TCP SRQ connection",
+                    self.port,
+                    remaining,
+                )
                 if len(data) > 0 and remaining <= 4:
                     chunk = b""  # Treat as short read
                     break
                 raise TimeoutError
             if not chunk:
-                LOGGER.debug("TCP SRQ (%d): peer closed connection while receiving payload", self.port)
+                LOGGER.debug(
+                    "TCP SRQ (%d): peer closed connection while receiving payload",
+                    self.port,
+                )
                 return None
 
             data += chunk
             remaining = n - len(data)
             if remaining > 0 and len(data) > 0 and remaining <= 4:
-                LOGGER.debug("TCP SRQ (%d): missing %d bytes, treating as short read", self.port, remaining)
+                LOGGER.debug(
+                    "TCP SRQ (%d): missing %d bytes, treating as short read",
+                    self.port,
+                    remaining,
+                )
                 break
         LOGGER.debug(
             "TCP SRQ (%d): Received %d bytes: %r",
@@ -516,7 +535,11 @@ class SrqInterruptTCPServer(rpc.TCPServer):
         handle = self.unpacker.unpack_opaque()
         self.turn_around()
         if handle != b"srq":
-            LOGGER.warning("TCP SRQ (%d): Ignoring VXI-11 SRQ with unexpected handle: %r", self.port, handle)
+            LOGGER.warning(
+                "TCP SRQ (%d): Ignoring VXI-11 SRQ with unexpected handle: %r",
+                self.port,
+                handle,
+            )
             return
         self._srq_queue.put(True)
 
@@ -530,4 +553,6 @@ class SrqInterruptTCPServer(rpc.TCPServer):
             )
             self.session._fire_event(constants.EventType.service_request, ctx)
         except Exception:
-            LOGGER.exception("TCP SRQ (%d): Error handling VXI-11 SRQ interrupt", self.port)
+            LOGGER.exception(
+                "TCP SRQ (%d): Error handling VXI-11 SRQ interrupt", self.port
+            )

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -492,7 +492,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                 return None
             data += chunk
         LOGGER.debug(
-            f"TCP SRQ: Received {len(data)} bytes from TCP SRQ connection: {data}"
+            "TCP SRQ: Received %d bytes from TCP SRQ connection: %r",
+            len(data),
+            data,
         )
         return data
 

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -491,7 +491,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                 LOGGER.debug("TCP SRQ: timeout")
                 return None
             data += chunk
-        LOGGER.debug(f"TCP SRQ: Received {len(data)} bytes from TCP SRQ connection: {data}")
+        LOGGER.debug(
+            f"TCP SRQ: Received {len(data)} bytes from TCP SRQ connection: {data}"
+        )
         return data
 
     def handle_30(self):

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -409,14 +409,17 @@ class SrqInterruptTCPServer(rpc.TCPServer):
     def loop(self):
         """Accept connections from the instrument and handle SRQ until stopped."""
         self.sock.settimeout(1.0)
+        self.port = self.sock.getsockname()[1]
         stop_flag = self.session._event_state.stop_flag
         while not stop_flag.is_set():
+            LOGGER.debug("TCP SRQ (%d): Waiting for new connection from instrument", self.port)
             try:
                 conn, _addr = self.sock.accept()
-            except socket.timeout:
+            except TimeoutError:
                 continue
             except OSError:
                 break
+            LOGGER.debug("TCP SRQ (%d): Accepted connection from %s", self.port, _addr)
             try:
                 self._handle_connection(conn)
             finally:
@@ -441,8 +444,9 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                     # Read record marker (4 bytes)
                     marker = self._recv_all(conn, 4)
                     if marker is None:
+                        LOGGER.debug("TCP SRQ (%d): Connection closed by peer", self.port)
                         return  # Connection closed by peer
-                except socket.timeout:
+                except TimeoutError:
                     continue
 
                 frag = struct.unpack(">I", marker)[0]
@@ -470,29 +474,38 @@ class SrqInterruptTCPServer(rpc.TCPServer):
                 self.handle(call)
                 # a reply to this call is not expected nor recommended for DEVICE_INTR_SRQ.
         except Exception:
-            LOGGER.exception("Error handling TCP SRQ connection")
+            LOGGER.exception("TCP SRQ (%d): Error handling TCP SRQ connection", self.port)
 
     def _recv_all(self, sock, n):
+        LOGGER.debug("TCP SRQ (%d): Receiving %d bytes from TCP SRQ connection", self.port, n)
+        remaining = n
         data = b""
         while len(data) < n:
-            remaining = n - len(data)
             # Some instruments omit the final 4 bytes of a VXI-11 SRQ fragment.
             # If we already received a partial payload, treat a timeout while waiting for
             # the last 1-4 bytes as a valid short read instead of dropping the SRQ.
+            # LOGGER.debug("TCP SRQ (%d): %d out of %d bytes remaining to receive", self.port, remaining, n)
+            
             try:
                 chunk = sock.recv(remaining)
-            except socket.timeout:
+            except TimeoutError:
+                LOGGER.debug("TCP SRQ (%d): timeout while receiving %d bytes from TCP SRQ connection", self.port, remaining)
                 if len(data) > 0 and remaining <= 4:
-                    LOGGER.debug(
-                        "TCP SRQ: timed out after partial payload; treating %d missing bytes as short read",
-                        remaining,
-                    )
+                    chunk = b""  # Treat as short read
                     break
-                LOGGER.debug("TCP SRQ: timeout")
+                raise TimeoutError
+            if not chunk:
+                LOGGER.debug("TCP SRQ (%d): peer closed connection while receiving payload", self.port)
                 return None
+
             data += chunk
+            remaining = n - len(data)
+            if remaining > 0 and len(data) > 0 and remaining <= 4:
+                LOGGER.debug("TCP SRQ (%d): missing %d bytes, treating as short read", self.port, remaining)
+                break
         LOGGER.debug(
-            "TCP SRQ: Received %d bytes from TCP SRQ connection: %r",
+            "TCP SRQ (%d): Received %d bytes: %r",
+            self.port,
             len(data),
             data,
         )
@@ -503,7 +516,7 @@ class SrqInterruptTCPServer(rpc.TCPServer):
         handle = self.unpacker.unpack_opaque()
         self.turn_around()
         if handle != b"srq":
-            LOGGER.warning("Ignoring VXI-11 SRQ with unexpected handle: %r", handle)
+            LOGGER.warning("TCP SRQ (%d): Ignoring VXI-11 SRQ with unexpected handle: %r", self.port, handle)
             return
         self._srq_queue.put(True)
 
@@ -517,4 +530,4 @@ class SrqInterruptTCPServer(rpc.TCPServer):
             )
             self.session._fire_event(constants.EventType.service_request, ctx)
         except Exception:
-            LOGGER.exception("Error handling VXI-11 SRQ interrupt")
+            LOGGER.exception("TCP SRQ (%d): Error handling VXI-11 SRQ interrupt", self.port)

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -492,7 +492,6 @@ class SrqInterruptTCPServer(rpc.TCPServer):
             # Some instruments omit the final 4 bytes of a VXI-11 SRQ fragment.
             # If we already received a partial payload, treat a timeout while waiting for
             # the last 1-4 bytes as a valid short read instead of dropping the SRQ.
-            # LOGGER.debug("TCP SRQ (%d): %d out of %d bytes remaining to receive", self.port, remaining, n)
 
             try:
                 chunk = sock.recv(remaining)

--- a/pyvisa_py/protocols/vxi11.py
+++ b/pyvisa_py/protocols/vxi11.py
@@ -475,10 +475,23 @@ class SrqInterruptTCPServer(rpc.TCPServer):
     def _recv_all(self, sock, n):
         data = b""
         while len(data) < n:
-            chunk = sock.recv(n - len(data))
-            if not chunk:
+            remaining = n - len(data)
+            # Some instruments omit the final 4 bytes of a VXI-11 SRQ fragment.
+            # If we already received a partial payload, treat a timeout while waiting for
+            # the last 1-4 bytes as a valid short read instead of dropping the SRQ.
+            try:
+                chunk = sock.recv(remaining)
+            except socket.timeout:
+                if len(data) > 0 and remaining <= 4:
+                    LOGGER.debug(
+                        "TCP SRQ: timed out after partial payload; treating %d missing bytes as short read",
+                        remaining,
+                    )
+                    break
+                LOGGER.debug("TCP SRQ: timeout")
                 return None
             data += chunk
+        LOGGER.debug(f"TCP SRQ: Received {len(data)} bytes from TCP SRQ connection: {data}")
         return data
 
     def handle_30(self):

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -662,6 +662,7 @@ class TCPIPInstrVxi11(Session):
         with self._srq_lifecycle_lock:
             self._event_state.stop_flag.set()
             try:
+                # even in disable, you must provide a body, so we use the same body as in enable
                 self.interface.device_enable_srq(self.link, False, b"srq")
             except Exception:
                 LOGGER.exception("Error disabling VXI-11 SRQ")

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -662,7 +662,7 @@ class TCPIPInstrVxi11(Session):
         with self._srq_lifecycle_lock:
             self._event_state.stop_flag.set()
             try:
-                self.interface.device_enable_srq(self.link, False, b"")
+                self.interface.device_enable_srq(self.link, False, b"srq")
             except Exception:
                 LOGGER.exception("Error disabling VXI-11 SRQ")
             try:

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -687,7 +687,7 @@ class TestVxi11SrqFlow:
         sess._srq_server.server_close = MagicMock()
         sess._event_state.stop_flag.set()
         TCPIPInstrVxi11._stop_event_monitor(sess)
-        sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"")
+        sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"srq")
         sess.interface.destroy_intr_chan.assert_called_once()
 
     def test_fire_event_then_wait_on_event(self, lib_and_session):

--- a/pyvisa_py/testsuite/test_events.py
+++ b/pyvisa_py/testsuite/test_events.py
@@ -687,7 +687,9 @@ class TestVxi11SrqFlow:
         sess._srq_server.server_close = MagicMock()
         sess._event_state.stop_flag.set()
         TCPIPInstrVxi11._stop_event_monitor(sess)
-        sess.interface.device_enable_srq.assert_called_once_with(sess.link, False, b"srq")
+        sess.interface.device_enable_srq.assert_called_once_with(
+            sess.link, False, b"srq"
+        )
         sess.interface.destroy_intr_chan.assert_called_once()
 
     def test_fire_event_then_wait_on_event(self, lib_and_session):


### PR DESCRIPTION
**Why**

This solves 2 rather serious bugs in VXI-11 SRQ handling:

1) Disabling SRQ causes a KS 34465A to crash
2) SRQ provokes hang and exceptions in pyvisa-py when SRQ is sent by a K DMM6500

**Details**

On point 1: The body of a SRQ disable message was empty, while it appears to be expected to be always filled in with something. 

On point 2: the DMM6500 (and likely maybe others from Keithley) sends the SRQ message 
* in a stream
* with the length indicator wrong: it says it is 4 bytes longer than it really is. 
 
The code was not prepared for that, but NI-Visa has no problems with it. pyvisa-py should neither.

**Tasks**

- [x] Closes #620
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests.
- [ ] Documented in docs/ as appropriate. No doc was available on this. and these are bugs, not features.
- [x] Added an entry to the CHANGES file
