### PR TITLE
List resources return socket

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- TCPIP::SOCKET can now also be found via `list_resources(query='TCPIP?*')` #622 PR #623
 - VXI-11: Allow link ID 0 to be used for SRQ in agreement with the specs
   and other implementations. Closes #618 PR #619
 - Removed return packet on device_intr_srq. Closes #614 PR #615

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,13 +27,16 @@ To discover VXI-11 devices on all network interfaces, please install
 `psutil`_. Otherwise, discovery will only occur on the default network
 interface.
 
-Discovery of both HiSLIP  and VICP devices relies on `mDNS`_, which is a protocol for
-service discovery in a local area network.  To enable resource
-discovery for HiSLIP and VICP, you should install `zeroconf`_.
+Discovery of HiSLIP, raw-socket (SOCKET) and VICP devices relies on `mDNS`_,
+which is a protocol for service discovery in a local area network.
+To enable resource discovery for those devices, you should install `zeroconf`_.
 
 The TCP/IP VICP protocol (proprietary to Teledyne LeCroy) depends on
 the `pyvicp`_ package.  You should install this package if you need to
 use VICP.
+
+Note that `list_resources()` and `list_resources_info()` by default only return `INSTR`
+resources.  Adapt those functions' `query` parameter to return other resource types.
 
 
 Serial resources: ASRL INSTR

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -553,7 +553,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         resources = list(
             set(resources)
         )  # Remove any duplicates that may have been found between
-           # the different classes.
+        # the different classes.
         return rname.filter(resources, query)
 
     def read(self, session: VISASession, count: int) -> Tuple[bytes, StatusCode]:

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -550,7 +550,9 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         resources: List[str] = []
         for key, st in Session.iter_valid_session_classes():
             resources += st.list_resources()
-        resources = list(set(resources))  # Remove duplicates, as prologix calls upon TCPIP sessions.
+        resources = list(
+            set(resources)
+        )  # Remove duplicates, as prologix calls upon TCPIP sessions.
         return rname.filter(resources, query)
 
     def read(self, session: VISASession, count: int) -> Tuple[bytes, StatusCode]:

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -552,7 +552,8 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
             resources += st.list_resources()
         resources = list(
             set(resources)
-        )  # Remove duplicates, as prologix calls upon TCPIP sessions.
+        )  # Remove any duplicates that may have been found between
+           # the different classes.
         return rname.filter(resources, query)
 
     def read(self, session: VISASession, count: int) -> Tuple[bytes, StatusCode]:

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -550,7 +550,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         resources: List[str] = []
         for key, st in Session.iter_valid_session_classes():
             resources += st.list_resources()
-
+        resources = list(set(resources))  # Remove duplicates, as prologix calls upon TCPIP sessions.
         return rname.filter(resources, query)
 
     def read(self, session: VISASession, count: int) -> Tuple[bytes, StatusCode]:

--- a/pyvisa_py/prologix.py
+++ b/pyvisa_py/prologix.py
@@ -145,6 +145,15 @@ class PrologixTCPIPIntfcSession(_PrologixIntfcSession, TCPIPSocketSession):
     # used for specific kinds of resources
     parsed: rname.TCPIPSocket
 
+    @staticmethod
+    def list_resources(wait_time=1.0) -> list[str]:
+        # There is no known fast method of distinguishing Prologix TCPIP interfaces
+        # from other TCPIP devices, so we return an empty list.
+        # If I do not define this method, the base class will call
+        # TCPIPSocketSession.list_resources(), which would create duplicates
+        # of all TCPIP::SOCKET resources, which is not what we want.
+        return []
+
     def write(self, data: bytes) -> tuple[int, StatusCode]:
         """Writes data to device or interface synchronously.
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -120,8 +120,11 @@ class TCPIPInstrHiSLIP(Session):
     def list_resources(wait_time=1.0) -> List[str]:
         resources = []
         try:
-            for host in get_services("_hislip._tcp.local.", wait_time=wait_time):
-                resources.append(f"TCPIP::{host}::hislip0,4880::INSTR")
+            for host,props in get_services("_hislip._tcp.local.", wait_time=wait_time).items():
+                port = 4880
+                if "port" in props:
+                    port = props["port"]
+                resources.append(f"TCPIP::{host}::hislip0,{port}::INSTR")
         except NotImplementedError:
             warnings.warn(
                 "TCPIP::hislip resource discovery requires the zeroconf package "
@@ -1257,9 +1260,22 @@ class TCPIPSocketSession(Session):
     parsed: rname.TCPIPSocket
 
     @staticmethod
-    def list_resources() -> List[str]:
-        # TODO: is there a way to get this?
-        return []
+    def list_resources(wait_time=1.0) -> List[str]:
+        resources = []
+        
+        try:
+            for host,props in get_services("_scpi-raw._tcp.local.", wait_time=wait_time).items():
+                port = 5025
+                if "port" in props:
+                    port = props["port"]                
+                resources.append(f"TCPIP::{host}::{port}::SOCKET")
+        except NotImplementedError:
+            warnings.warn(
+                "TCPIP::SOCKET resource discovery requires the zeroconf package "
+                "to be installed... try 'pip install zeroconf'",
+                UserWarning,
+            )
+        return sorted(resources)
 
     def after_parsing(self) -> None:
         # TODO: board_number not handled
@@ -1624,6 +1640,7 @@ def get_services(service_type: str, wait_time: float = 0.1) -> Dict[str, dict]:
             if info is None:
                 return
             properties = {}
+            properties["port"] = info.port
             for key, val in info.properties.items():
                 if key == b"txtvers":
                     continue

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -120,7 +120,9 @@ class TCPIPInstrHiSLIP(Session):
     def list_resources(wait_time=1.0) -> List[str]:
         resources = []
         try:
-            for host,props in get_services("_hislip._tcp.local.", wait_time=wait_time).items():
+            for host, props in get_services(
+                "_hislip._tcp.local.", wait_time=wait_time
+            ).items():
                 port = 4880
                 if "port" in props:
                     port = props["port"]
@@ -1262,12 +1264,14 @@ class TCPIPSocketSession(Session):
     @staticmethod
     def list_resources(wait_time=1.0) -> List[str]:
         resources = []
-        
+
         try:
-            for host,props in get_services("_scpi-raw._tcp.local.", wait_time=wait_time).items():
+            for host, props in get_services(
+                "_scpi-raw._tcp.local.", wait_time=wait_time
+            ).items():
                 port = 5025
                 if "port" in props:
-                    port = props["port"]                
+                    port = props["port"]
                 resources.append(f"TCPIP::{host}::{port}::SOCKET")
         except NotImplementedError:
             warnings.warn(

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -115,6 +115,8 @@ class TCPIPInstrHiSLIP(Session):
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource
     parsed: rname.TCPIPInstr
+    
+    default_tcpip_port = 4880
 
     @staticmethod
     def list_resources(wait_time=1.0) -> List[str]:
@@ -123,7 +125,7 @@ class TCPIPInstrHiSLIP(Session):
             for host, props in get_services(
                 "_hislip._tcp.local.", wait_time=wait_time
             ).items():
-                port = 4880
+                port = TCPIPInstrHiSLIP.default_tcpip_port
                 if "port" in props:
                     port = props["port"]
                 resources.append(f"TCPIP::{host}::hislip0,{port}::INSTR")
@@ -143,7 +145,7 @@ class TCPIPInstrHiSLIP(Session):
             port = int(port_str)
         else:
             sub_address = self.parsed.lan_device_name
-            port = 4880
+            port = self.default_tcpip_port
 
         try:
             self.interface = hislip.Instrument(
@@ -1260,6 +1262,8 @@ class TCPIPSocketSession(Session):
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource
     parsed: rname.TCPIPSocket
+    
+    default_tcpip_port = 5025
 
     @staticmethod
     def list_resources(wait_time=1.0) -> List[str]:
@@ -1269,7 +1273,7 @@ class TCPIPSocketSession(Session):
             for host, props in get_services(
                 "_scpi-raw._tcp.local.", wait_time=wait_time
             ).items():
-                port = 5025
+                port = TCPIPSocketSession.default_tcpip_port
                 if "port" in props:
                     port = props["port"]
                 resources.append(f"TCPIP::{host}::{port}::SOCKET")

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -115,7 +115,7 @@ class TCPIPInstrHiSLIP(Session):
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource
     parsed: rname.TCPIPInstr
-    
+
     default_tcpip_port = 4880
 
     @staticmethod
@@ -1262,7 +1262,7 @@ class TCPIPSocketSession(Session):
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource
     parsed: rname.TCPIPSocket
-    
+
     default_tcpip_port = 5025
 
     @staticmethod


### PR DESCRIPTION
- [x] Closes #622
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests.
- [x] Documented in docs/ as appropriate. Done
- [x] Added an entry to the CHANGES file

Unittest is a bit hard to do, as this requires mDNS.

This also corrects the hislip port that was hard coded to 4880, but can be something else.

I chose NOT to add vxi-11 lookups via mDNS, as portmap is more reliable.