### PR TITLE
[vxi-11] Give the END indicator priority over the termination character

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,12 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- A VXI-11 read stopped by both the END indicator and the termination
+  character now reports ``VI_SUCCESS`` rather than
+  ``VI_SUCCESS_TERM_CHAR``. VPP-4.3 RULE 6.1.1 gives END priority over the
+  termination character. ``VI_SUCCESS_TERM_CHAR`` is also no longer
+  reported while ``VI_ATTR_TERMCHAR_EN`` is clear, which RULE 6.1.5
+  forbids. Follow-up to PR #612
 - USBTMC: fix long write PR #628
 - VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -693,12 +693,20 @@ class TCPIPInstrVxi11(Session):
                 pass
 
     def _read_status_from_reason(
-        self, reason: int, suppress_end_en: bool
+        self, reason: int, suppress_end_en: bool, termchar_en: bool
     ) -> StatusCode:
-        if reason & vxi11.RX_CHR:
-            return StatusCode.success_termination_character_read
+        """Completion status for a read, from the reason the device gave.
+
+        VPP-4.3 RULE 6.1.1 gives the END indicator priority: it is answered
+        regardless of whether the termination character was also read, so it
+        is tested first. RULE 6.1.4 withholds VI_SUCCESS while
+        VI_ATTR_SUPPRESS_END_EN is set, and RULE 6.1.5 withholds
+        VI_SUCCESS_TERM_CHAR while VI_ATTR_TERMCHAR_EN is clear.
+        """
         if reason & vxi11.RX_END and not suppress_end_en:
             return StatusCode.success
+        if reason & vxi11.RX_CHR and termchar_en:
+            return StatusCode.success_termination_character_read
         return StatusCode.success_max_count_read
 
     def read(self, count: int) -> Tuple[bytes, StatusCode]:
@@ -726,7 +734,8 @@ class TCPIPInstrVxi11(Session):
 
         chunk_length = min(count, self.max_recv_size)
 
-        if self.get_attribute(ResourceAttribute.termchar_enabled)[0]:
+        termchar_en, _ = self.get_attribute(ResourceAttribute.termchar_enabled)
+        if termchar_en:
             term_char, _ = self.get_attribute(ResourceAttribute.termchar)
             flags = vxi11.OP_FLAG_TERMCHAR_SET
         else:
@@ -785,13 +794,15 @@ class TCPIPInstrVxi11(Session):
             count -= len(data)
 
             if count <= 0:
-                status = self._read_status_from_reason(reason, suppress_end_en)
+                status = self._read_status_from_reason(
+                    reason, suppress_end_en, termchar_en
+                )
                 break
 
             chunk_length = min(count, chunk_length)
 
         if count > 0 and (reason & stop_reason):
-            status = self._read_status_from_reason(reason, suppress_end_en)
+            status = self._read_status_from_reason(reason, suppress_end_en, termchar_en)
 
         return bytes(read_data), status
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -703,9 +703,9 @@ class TCPIPInstrVxi11(Session):
         VI_ATTR_SUPPRESS_END_EN is set, and RULE 6.1.5 withholds
         VI_SUCCESS_TERM_CHAR while VI_ATTR_TERMCHAR_EN is clear.
         """
-        if reason & vxi11.RX_END and not suppress_end_en:
+        if not suppress_end_en and (reason & vxi11.RX_END):
             return StatusCode.success
-        if reason & vxi11.RX_CHR and termchar_en:
+        if termchar_en and (reason & vxi11.RX_CHR):
             return StatusCode.success_termination_character_read
         return StatusCode.success_max_count_read
 

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -194,3 +194,62 @@ class TestTCPIPInstrVxi11Read:
 
         assert data == b"ab"
         assert status == StatusCode.error_io
+
+    def test_read_gives_end_priority_over_termination_character(self):
+        # VPP-4.3 RULE 6.1.1: END is answered regardless of whether the
+        # termination character was also read.
+        sess = self._make_session(termchar_enabled=True)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_END | vxi11.RX_CHR,
+            b"abc",
+        )
+
+        data, status = sess.read(10)
+
+        assert data == b"abc"
+        assert status == StatusCode.success
+
+    def test_read_gives_end_priority_when_count_is_exhausted(self):
+        # Same rule on the path that leaves the loop because count ran out.
+        sess = self._make_session(termchar_enabled=True)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_END | vxi11.RX_CHR,
+            b"abc",
+        )
+
+        data, status = sess.read(3)
+
+        assert data == b"abc"
+        assert status == StatusCode.success
+
+    def test_read_ignores_rx_chr_when_termchar_is_disabled(self):
+        # VPP-4.3 RULE 6.1.5: VI_SUCCESS_TERM_CHAR is withheld while
+        # VI_ATTR_TERMCHAR_EN is clear, even if the device reports RX_CHR.
+        sess = self._make_session(termchar_enabled=False)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_CHR,
+            b"abc",
+        )
+
+        data, status = sess.read(3)
+
+        assert data == b"abc"
+        assert status == StatusCode.success_max_count_read
+
+    def test_read_withholds_success_when_end_is_suppressed(self):
+        # VPP-4.3 RULE 6.1.4: VI_SUCCESS is withheld while
+        # VI_ATTR_SUPPRESS_END_EN is set, so the termination character answers.
+        sess = self._make_session(termchar_enabled=True, suppress_end_enabled=True)
+        sess.interface.device_read.return_value = (
+            0,
+            vxi11.RX_END | vxi11.RX_CHR,
+            b"abc",
+        )
+
+        data, status = sess.read(10)
+
+        assert data == b"abc"
+        assert status == StatusCode.success_termination_character_read


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->
I missed getting a comment in about this before #612 was merged but I don't think the current behavior is correct:

A VXI-11 read that stops on both the END indicator and the termination character reported VI_SUCCESS_TERM_CHAR. VPP-4.3 RULE 6.1.1 requires VI_SUCCESS whenever END is received and VI_ATTR_SUPPRESS_END_EN is clear, regardless of whether the termination character was also read.

Instruments commonly assert END on the byte that carries the termination character, so the two arrive together in one reason and the RX_CHR test, which came first, always won.

VI_SUCCESS_TERM_CHAR is also no longer reported while VI_ATTR_TERMCHAR_EN is clear, which RULE 6.1.5 forbids. OP_FLAG_TERMCHAR_SET is only sent when the attribute is set, so this guards against an instrument that reports RX_CHR anyway.

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

cc @hb020 