### PR TITLE
Set the TCP keepalive probe timers only where they exist

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,9 @@ PyVISA-py Changelog
   character detection, allowed use of suppress_end_en, corrected timeout handling.
   Closes #608 PR #612
 - Fixed crash on DEVICE_ENABLE_SRQ(off) and accept malformed SRQ packets. Closes #620 PR #621
+- Set the TCP keepalive probe timers defensively for all TCPIP resources.
+  ``VI_ATTR_TCPIP_KEEPALIVE`` raised ``AttributeError`` on platforms without
+  ``socket.TCP_KEEPIDLE``, which includes macOS.
 - TCPIP::SOCKET can now also be found via `list_resources(query='TCPIP?*')` #622 PR #623
 - Apply ``open_timeout`` to the connection attempt across all the TCP
   transports, as VPP-4.3 PERMISSION 4.3.2 allows. An ``open_timeout`` of 0

--- a/pyvisa_py/common.py
+++ b/pyvisa_py/common.py
@@ -7,6 +7,7 @@
 """
 
 import logging
+import socket
 from typing import TYPE_CHECKING, Iterator, Optional
 
 from pyvisa import logger
@@ -19,6 +20,34 @@ if TYPE_CHECKING:
 else:
     BytesBuffer = bytes | bytearray | memoryview
     MutableBytesBuffer = bytearray | memoryview
+
+
+def set_keepalive(sock: socket.socket, keepalive: bool) -> None:
+    """Turn TCP keepalive on/off, tuning the probe timers where possible.
+
+    ``TCP_KEEPIDLE``/``TCP_KEEPINTVL``/``TCP_KEEPCNT`` are not available on
+    every platform (notably ``TCP_KEEPIDLE`` is missing on macOS, which spells
+    it ``TCP_KEEPALIVE``), so each one is applied only if the running
+    interpreter exposes it.
+
+    """
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1 if keepalive else 0)
+    if not keepalive:
+        return
+
+    for name, value in (
+        ("TCP_KEEPIDLE", 60),
+        ("TCP_KEEPALIVE", 60),  # macOS spelling of TCP_KEEPIDLE
+        ("TCP_KEEPINTVL", 60),
+        ("TCP_KEEPCNT", 5),
+    ):
+        option = getattr(socket, name, None)
+        if option is None:
+            continue
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, option, value)
+        except OSError:
+            LOGGER.debug("could not set socket option %s", name, exc_info=True)
 
 
 class NamedObject(object):

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -22,7 +22,7 @@ from pyvisa import attributes, constants, errors, rname
 from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
 from pyvisa.typing import VISAJobID
 
-from .common import LOGGER, connect_timeout, int_to_byte
+from .common import LOGGER, connect_timeout, int_to_byte, set_keepalive
 from .protocols import hislip, rpc, vxi11
 from .sessions import OpenError, Session, UnknownAttribute, VISARMSession
 
@@ -893,23 +893,10 @@ class TCPIPInstrVxi11(Session):
         # https://tech.xing.com/a-reason-for-unexplained-connection-timeouts-on-kubernetes-docker-abd041cf7e02
         if attribute == constants.VI_ATTR_TCPIP_KEEPALIVE:
             if attribute_state is True:
-                self.interface.sock.setsockopt(
-                    socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1
-                )
-                self.interface.sock.setsockopt(
-                    socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60
-                )
-                self.interface.sock.setsockopt(
-                    socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60
-                )
-                self.interface.sock.setsockopt(
-                    socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5
-                )
+                set_keepalive(self.interface.sock, True)
                 self.keepalive = True
             elif attribute_state is False:
-                self.interface.sock.setsockopt(
-                    socket.SOL_SOCKET, socket.SO_KEEPALIVE, 0
-                )
+                set_keepalive(self.interface.sock, False)
                 self.keepalive = False
             else:
                 return StatusCode.error_nonsupported_format
@@ -1603,12 +1590,7 @@ class TCPIPSocketSession(Session):
         self, attribute: ResourceAttribute, attribute_state: bool
     ) -> StatusCode:
         if self.interface:
-            self.interface.setsockopt(
-                socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1 if attribute_state else 0
-            )
-            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)
-            self.interface.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
+            set_keepalive(self.interface, bool(attribute_state))
             return StatusCode.success
         return StatusCode.error_nonsupported_attribute
 

--- a/pyvisa_py/testsuite/test_common.py
+++ b/pyvisa_py/testsuite/test_common.py
@@ -1,3 +1,4 @@
+import socket
 from typing import List, Optional
 
 import pytest
@@ -100,3 +101,20 @@ def test_iter_bytes_with_send_end_requires_data_bits() -> None:
 def test_iter_bytes_raises_on_bad_data_bits() -> None:
     with pytest.raises(ValueError):
         list(common.iter_bytes(b"", data_bits=0, send_end=None))
+
+
+@pytest.mark.parametrize("keepalive", [True, False])
+def test_set_keepalive(keepalive: bool) -> None:
+    """The probe timers are not named the same way on every platform.
+
+    TCP_KEEPIDLE does not exist on macOS, which calls it TCP_KEEPALIVE.
+    Setting it unconditionally raised AttributeError, so enabling
+    VI_ATTR_TCPIP_KEEPALIVE failed there for every TCPIP resource.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        common.set_keepalive(sock, keepalive)
+        enabled = sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+        assert bool(enabled) is keepalive
+    finally:
+        sock.close()


### PR DESCRIPTION
VI_ATTR_TCPIP_KEEPALIVE set TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT without checking that the running interpreter has them. TCP_KEEPIDLE does not exist on macOS, which calls the same option TCP_KEEPALIVE, so enabling keepalive there raised AttributeError for VXI-11 and TCPIP::SOCKET resources.

The three call sites now share common.set_keepalive, which applies each probe timer only if it is available and always sets SO_KEEPALIVE, so the attribute does what it says on every platform and tunes the timers where it can.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate -> I don't think any docs are needed here 
- [x] Added an entry to the CHANGES file
