### PR TITLE
VXI11 lock handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,8 +6,9 @@ PyVISA-py Changelog
 
 - VXI-11 (TCPIP::INSTR):
   Locking compliance improvement. Exclusive locking works now,
-  and forcing `session.lock_timeout = 0` should no longer be needed for instruments
+  Removed `session.lock_timeout`, no longer needed for instruments
   that have flawed VXI-11 implementations like the DM3068.
+  Added attribute VI_KTATTR_LOCKWAIT.
   Corrected error codes.
   Closes #583 PR #633
 - A VXI-11 read stopped by both the END indicator and the termination

--- a/CHANGES
+++ b/CHANGES
@@ -4,9 +4,11 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- VXI-11 (TCPIP::INSTR) Locking compliance improvement. Exclusive locking works now,
+- VXI-11 (TCPIP::INSTR):
+  Locking compliance improvement. Exclusive locking works now,
   and forcing `session.lock_timeout = 0` should no longer be needed for instruments
   that have flawed VXI-11 implementations like the DM3068.
+  Corrected error codes.
   Closes #583 PR #???
 - VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ PyVISA-py Changelog
   and forcing `session.lock_timeout = 0` should no longer be needed for instruments
   that have flawed VXI-11 implementations like the DM3068.
   Corrected error codes.
-  Closes #583 PR #???
+  Closes #583 PR #633
 - USBTMC: fix long write PR #628
 - VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,8 @@ PyVISA-py Changelog
 
 - VXI-11 (TCPIP::INSTR) Locking compliance improvement. Exclusive locking works now,
   and forcing `session.lock_timeout = 0` should no longer be needed for instruments
-  that have flawed VXI-11 implementations like the DM3068. Closes #583 PR #???
+  that have flawed VXI-11 implementations like the DM3068.
+  Closes #583 PR #???
 - VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple
   of chunk_size, implemented read count boundary checks, completed termination

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- VXI-11 (TCPIP::INSTR) Locking compliance improvement. Exclusive locking works now,
+  and forcing `session.lock_timeout = 0` should no longer be needed for instruments
+  that have flawed VXI-11 implementations like the DM3068. Closes #583 PR #???
 - VXI-11 (TCPIP::INSTR) Read function termination overhaul:
   Corrected timeout in read when response length is an exact multiple
   of chunk_size, implemented read count boundary checks, completed termination

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -233,7 +233,7 @@ in case another program or session has locked it, you must choose one of the fol
     that already has a lock: they should reply immediately with ``VI_ERROR_RSRC_LOCKED``.
     However, in practice this is not always the case, and some instruments take quite some liberties with it.    
 
-    ``VI_KTATTR_LOCKWAIT`` may not be available yet in PyVISA. In that case, you could do this:
+    ``pyvisa.constants.VI_KTATTR_LOCKWAIT`` may not be available yet in PyVISA. In that case, you could do this:
 
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -176,7 +176,7 @@ Locking
 **PyVISA-Py only supports exclusive locking, and only on VXI-11. Shared locks and nested locking are not supported.** 
 
 Socket instruments (``TCPIP::SOCKET``) do not support locking.
-HiSLIP instruments (``TCPIP::hislip0``) could support locking, but PyVISA-Py does not yet implement this feature.
+HiSLIP instruments (``TCPIP::hislip``) could support locking, but PyVISA-Py does not yet implement this feature.
 
 With exclusive locking, only one session can be used at a time on an instrument.  
 If another session has a lock, another client will not be able to communicate with

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -63,13 +63,13 @@ Are GBIP secondary addresses supported?
 GPIB secondary addresses are supported in NI-VISA fashion, meaning that the
 secondary address is not 96 to 126 as transmitted on the bus, but 0 to 30.
 
-For expample, `GPIB0::9::1::INSTR` is the address of the first VXI module
-controlled by a GPIB VXI command module set to primary address `9`, while
-the command module itself is found at `GPIB0::9::0::INSTR`, which is distinct
-from a pure primary address like `GPIB0::9::INSTR`.
+For expample, ``GPIB0::9::1::INSTR`` is the address of the first VXI module
+controlled by a GPIB VXI command module set to primary address ``9``, while
+the command module itself is found at ``GPIB0::9::0::INSTR``, which is distinct
+from a pure primary address like ``GPIB0::9::INSTR``.
 
 ``ResourceManager.list_resources()`` can discover both primary and secondary 
-addressable `GPIB::...::INSTR` resources. As a result, it can be slow,
+addressable ``GPIB::...::INSTR`` resources. As a result, it can be slow,
 as it now needs to check 992 addresses per GPIB controller instead of just 31.
 
 For every primary address where no listener is detected, all
@@ -82,12 +82,12 @@ checked as most devices simply ignore secondary addressing.
 If you have an instrument that reacts to the primary address and has different
 functionality on some secondary addresses, please leave a bug report.
 
-If you use a VXI-11.2 gateway (VXI-11 to GPIB), you can use constructions like 
-`TCPIP::host::gpib0,9,1::INSTR`, where `gpib0` is the 'GPIB SICL Interface Name' 
-configured on the gateway, `9` is the primary address of the instrument, 
-and `1` is the secondary address of that instrument.
+If you use a VXI-11.2 (VXI-11 to GPIB) gateway, you can use constructions like 
+``TCPIP::host::gpib0,9,1::INSTR``, where ``gpib0`` is the 'GPIB SICL Interface Name' 
+configured on the gateway, ``9`` is the primary address of the instrument, 
+and ``1`` is the secondary address of that instrument.
 ``ResourceManager.list_resources()`` will however not try to discover any resources
-on a VXI-11.2 gateway, as the SICL Interface Name is not automatically known.
+behind a VXI-11.2 gateway, as the SICL Interface Name is not automatically known.
 
 
 Can PyVISA-py be used from a VM?
@@ -107,12 +107,12 @@ As the Windows variant of Docker can forward neither USB ports nor GPIB
 interfaces, the obvious choice would be to connect via TCP/IP. The problem of a
 Docker container is that idle connections are disconnected by the VPN garbage
 collection. For this reason it is reasonable to enable keepalive packets.
-The VISA attribute `VI_ATTR_TCPIP_KEEPALIVE` has been modified to work
+The VISA attribute ``VI_ATTR_TCPIP_KEEPALIVE`` has been modified to work
 for all TCP/IP instruments. Enabling this option can be done with:
 
     >>> inst.set_visa_attribute(pyvisa.constants.ResourceAttribute.tcpip_keepalive, True)
 
-where `inst` is an active TCP/IP visa session.
+where ``inst`` is an active TCP/IP visa session.
 (see https://tech.xing.com/a-reason-for-unexplained-connection-timeouts-on-kubernetes-docker-abd041cf7e02
 if you want to read more about connection dropping in docker containers)
 
@@ -179,9 +179,11 @@ Socket instruments (``TCPIP::SOCKET``) do not support locking.
 HiSLIP instruments (``TCPIP::hislip0``) could support locking, but PyVISA-Py does not yet implement this feature.
 
 With exclusive locking, only one session can be used at a time on an instrument.  
-If another session has a lock, another client calling `open_resource` may or may not succeed, 
-and, if opened, most operations will fail. In that case, expect error codes ``VI_ERROR_RSRC_LOCKED`` 
-(as it should), or ``VI_ERROR_TMO`` or ``VI_ERROR_RSRC_BUSY``.
+If another session has a lock, another client will not be able to communicate with
+the instrument. Either ``open_resource`` will fail, either ``read`` / ``write`` / ``query`` /... 
+operations will fail. 
+The related error codes in that case are:
+``VI_ERROR_RSRC_LOCKED`` (as it should), or ``VI_ERROR_TMO`` or ``VI_ERROR_RSRC_BUSY``.
 
 There are two ways of using exclusive locking on an instrument session via pyvisa:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -149,8 +149,8 @@ establishing the connection::
     >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000)
 
 If you do not specify ``open_timeout``, the connection attempt is given 2000 ms.  An
-``open_timeout`` of 0 selects that same default rather than meaning "give up
-immediately", since ``ResourceManager.open_resource`` passes 0 whenever you
+``open_timeout`` of ``0`` selects that same default rather than meaning "give up
+immediately", since ``ResourceManager.open_resource`` passes ``0`` whenever you
 omit the argument.
 
 .. note::
@@ -203,7 +203,7 @@ default is ``pyvisa.constants.AccessModes.no_lock``, which does not request a lo
 The connection will be established with the same timeout handling as mentioned above,
 but will then try to open a link with a lock timeout also governed by ``open_timeout``.
 That lock request will succeed if the instrument grants it within this period.
-An ``open_timeout`` of 0 or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
+An ``open_timeout`` of ``0`` or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
 while None means "10 seconds", and ``VI_TMO_INFINITE`` means "wait indefinitely".
 
 If you want better control over the different timeout settings, use "lock after open":
@@ -216,31 +216,42 @@ If you want better control over the different timeout settings, use "lock after 
     >>> inst.lock_excl(timeout=10000)
 
 If you have not locked the instrument, and want to control the behaviour of your program
-in case another program or session has locked it, you can either request a lock 
-(``inst.lock_excl()``), or use ``rm.visalib.sessions[inst.session].lock_timeout`` 
-to control a lock timeout on most operation on the instrument. 
-If you set it to `0`, an operation on an instrument that is locked by another session 
-will fail immediately. 
-If set to a positive value, it will wait for that many milliseconds for the lock to 
-be removed before failing. 
-The default value of ``lock_timeout`` is 0 or ``VI_TMO_IMMEDIATE`` (do not wait).
+in case another program or session has locked it, you must choose one of the following methods:
 
-Note that ``open_resource`` and ``lock_excl`` use their own timeout values, and do not use ``lock_timeout``.
+- Request a lock via ``inst.lock_excl()``. This is the most portable. See above.
+- Configure the lock timeout via the PyVISA-Py specific ``rm.visalib.sessions[inst.session].lock_timeout``.  
+
+    When using ``lock_timeout`` on an instrument that is locked by another session:
+
+    - If ``0``, operations will fail immediately. 
+    - If set to a positive value, operations will wait for that many milliseconds for the lock to be removed before failing. 
+
+    The default value of ``lock_timeout`` is ``0`` or ``VI_TMO_IMMEDIATE`` (do not wait).
+
+Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``lock_timeout``.
 
 Event handling is not affected by locking. 
 
 
 .. note::
 
-    **Portability:** Exclusive locking should work, but some devices (even recent ones from the big brands),
-    and also some of the VISA backends, use a certain amount of liberties. Do not expect respect of the following:
+    **Portability:** Use of `lock_excl()` is the most portable and robust way to request a lock.
+    
+    Know that some devices (even recent ones from the big brands), and all of the VISA 
+    backends, use a certain amount of liberties with regards to the standards. 
+    Do not expect respect of the following:
 
-    - the prescribed return codes (meaning: you may see "I/O Timeout" instead of "Resource already locked"),
-    - the length of the timeouts (timeouts may be significantly longer than specified)
+    - the prescribed return codes (example: you may see "I/O Timeout" instead of "Resource already locked"),
+    - the length of the timeouts (timeouts may be significantly longer or shorter than specified)
     - the sequencing: some devices, once already locked, will allow `open_resource`
       to succeed (as they should per VXI-11 spec RULE B.6.6), but others don't.
 
-    If you are debugging locking issues, note that NI-Visa supports
+    Keysight VISA supports the lock timeout attribute ``VI_KTATTR_LOCKWAIT``.
+
+    NI-VISA and R&S VISA have no known means of controlling the lock timeout, and mostly 
+    use the I/O timeout and/or internal timing for lock timeout handling.
+
+    If you are debugging locking issues, note that NI-VISA supports
     the lock-on-open method, but underneath uses the lock-after-open method, and, 
     after having established a lock, handles the locking internally without addressing
     the instrument.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -228,7 +228,12 @@ in case another program or session has locked it, you must choose one of the fol
 
     The default value of ``VI_KTATTR_LOCKWAIT`` is ``FALSE/0`` (do not wait).
 
-    ``VI_KTATTR_LOCKWAIT`` may not be available yet in pyvisa. In that case, you could do this:
+    In theory ``VI_KTATTR_LOCKWAIT = False`` should behave the same as 
+    ``inst.timeout = 0`` + ``VI_KTATTR_LOCKWAIT = True`` when applied to an operation on an instrument 
+    that already has a lock: they should reply immediately with ``VI_ERROR_RSRC_LOCKED``.
+    However, in practice this is not always the case, and some instruments take quite some liberties with it.    
+
+    ``VI_KTATTR_LOCKWAIT`` may not be available yet in PyVISA. In that case, you could do this:
 
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')
@@ -248,14 +253,15 @@ in case another program or session has locked it, you must choose one of the fol
 
 Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``VI_KTATTR_LOCKWAIT``.
 
-``lock_timeout`` from previous PyVISA-Py versions has been removed.
+``session.lock_timeout``, from previous PyVISA-Py versions, has been removed, and replaced by the 
+use of ``VI_KTATTR_LOCKWAIT``, as it is easier, more predictable and more portable.
 
 Event handling is not affected by locking. 
 
 
 .. note::
 
-    **Portability:** Use of `lock_excl()` is the most portable and robust way to request a lock.
+    **Portability:** Use of `lock_excl()` is the most portable, robust, and predictable way to handle locking.
     
     Know that some devices (even recent ones from the big brands), and all of the VISA 
     backends, use a certain amount of liberties with regards to the standards. 
@@ -266,7 +272,7 @@ Event handling is not affected by locking.
     - the sequencing: some devices, once already locked, will allow `open_resource`
       to succeed (as they should per VXI-11 spec RULE B.6.6), but others don't.
 
-    Keysight VISA supports the lock timeout attribute ``VI_KTATTR_LOCKWAIT``.
+    Keysight VISA and PyVISA-py both support the lock timeout attribute ``VI_KTATTR_LOCKWAIT``.
 
     NI-VISA and R&S VISA have no known means of controlling the lock timeout, and mostly 
     use the I/O timeout and/or internal timing for lock timeout handling.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -24,15 +24,15 @@ The blocked read will return with ``VI_ERROR_ABORT``.  The HiSLIP protocol
 state is automatically reset (via a device clear) so the session is ready for
 further I/O immediately::
 
-    import pyvisa
-    rm = pyvisa.ResourceManager('@py')
-    inst = rm.open_resource('TCPIP::192.168.1.100::hislip0::INSTR')
-
-    # From another thread, to cancel a blocked read:
-    inst.visalib.terminate(inst.session, None, None)
-
-    # The blocked read returns VI_ERROR_ABORT.
-    # The session is ready for further I/O — no manual viClear() needed.
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::hislip0::INSTR')
+    >>> 
+    >>> # From another thread, to cancel a blocked read:
+    >>> inst.visalib.terminate(inst.session, None, None)
+    >>> 
+    >>> # The blocked read returns VI_ERROR_ABORT.
+    >>> # The session is ready for further I/O — no manual viClear() needed.
 
 ``viTerminate()`` is not yet supported for VXI-11, USBTMC, or serial sessions.
 
@@ -43,7 +43,7 @@ further I/O immediately::
     Libraries' ``viTerminate()`` returns ``VI_SUCCESS`` but does not actually
     cancel a blocked synchronous ``viRead()`` — the read continues until the
     normal timeout expires.  The VISA specification defines ``viTerminate()``
-    primarily for asynchronous operations (``viReadAsync``/``viWriteAsync``),
+    primarily for asynchronous operations (``viReadAsync`` / ``viWriteAsync``),
     and its behavior on synchronous calls is implementation-defined.  Code
     that relies on ``viTerminate()`` cancelling a synchronous read may not
     be portable to other VISA backends.
@@ -68,7 +68,8 @@ controlled by a GPIB VXI command module set to primary address `9`, while
 the command module itself is found at `GPIB0::9::0::INSTR`, which is distinct
 from a pure primary address like `GPIB0::9::INSTR`.
 
-``ResourceManager.list_resources()`` has become slower as a result,
+``ResourceManager.list_resources()`` can discover both primary and secondary 
+addressable `GPIB::...::INSTR` resources. As a result, it can be slow,
 as it now needs to check 992 addresses per GPIB controller instead of just 31.
 
 For every primary address where no listener is detected, all
@@ -78,8 +79,15 @@ VXI modules controlled by an HP E1406A.
 For primary addresses where a listener is detected, no secondary addresses are
 checked as most devices simply ignore secondary addressing.
 
-If you have a device that reacts to the primary address and has different
+If you have an instrument that reacts to the primary address and has different
 functionality on some secondary addresses, please leave a bug report.
+
+If you use a VXI-11.2 gateway (VXI-11 to GPIB), you can use constructions like 
+`TCPIP::host::gpib0,9,1::INSTR`, where `gpib0` is the 'GPIB SICL Interface Name' 
+configured on the gateway, `9` is the primary address of the instrument, 
+and `1` is the secondary address of that instrument.
+``ResourceManager.list_resources()`` will however not try to discover any resources
+on a VXI-11.2 gateway, as the SICL Interface Name is not automatically known.
 
 
 Can PyVISA-py be used from a VM?
@@ -102,7 +110,7 @@ collection. For this reason it is reasonable to enable keepalive packets.
 The VISA attribute `VI_ATTR_TCPIP_KEEPALIVE` has been modified to work
 for all TCP/IP instruments. Enabling this option can be done with:
 
-    inst.set_visa_attribute(pyvisa.constants.ResourceAttribute.tcpip_keepalive, True)
+    >>> inst.set_visa_attribute(pyvisa.constants.ResourceAttribute.tcpip_keepalive, True)
 
 where `inst` is an active TCP/IP visa session.
 (see https://tech.xing.com/a-reason-for-unexplained-connection-timeouts-on-kubernetes-docker-abd041cf7e02
@@ -165,10 +173,15 @@ omit the argument.
 Locking
 -------
 
-**PyVISA-Py only supports exclusive locking, and only on VXI-11. Shared locks are not supported.** 
+**PyVISA-Py only supports exclusive locking, and only on VXI-11. Shared locks and nested locking are not supported.** 
 
 Socket instruments (``TCPIP::SOCKET``) do not support locking.
 HiSLIP instruments (``TCPIP::hislip0``) could support locking, but PyVISA-Py does not yet implement this feature.
+
+With exclusive locking, only one session can be used at a time on an instrument.  
+If another session has a lock, another client calling `open_resource` may or may not succeed, 
+and, if opened, most operations will fail. In that case, expect error codes ``VI_ERROR_RSRC_LOCKED`` 
+(as it should), or ``VI_ERROR_TMO`` or ``VI_ERROR_RSRC_BUSY``.
 
 There are two ways of using exclusive locking on an instrument session via pyvisa:
 
@@ -198,7 +211,22 @@ If you want better control over the different timeout settings, use "lock after 
     >>> # allow 3 s to reach the instrument
     >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=3000)
     >>> # and then try to acquire a lock on the instrument with a 10 s timeout
-    >>> inst.lock_excl(timeout=10000) 
+    >>> inst.lock_excl(timeout=10000)
+
+If you have not locked the instrument, and want to control the behaviour of your program
+in case another program or session has locked it, you can either request a lock 
+(``inst.lock_excl()``), or use ``rm.visalib.sessions[inst.session].lock_timeout`` 
+to control a lock timeout on most operation on the instrument. 
+If you set it to `0`, an operation on an instrument that is locked by another session 
+will fail immediately. 
+If set to a positive value, it will wait for that many milliseconds for the lock to 
+be removed before failing. 
+The default value of ``lock_timeout`` is 0 or ``VI_TMO_IMMEDIATE`` (do not wait).
+
+Note that ``open_resource`` and ``lock_excl`` use their own timeout values, and do not use ``lock_timeout``.
+
+Event handling is not affected by locking. 
+
 
 .. note::
 
@@ -207,17 +235,13 @@ If you want better control over the different timeout settings, use "lock after 
 
     - the prescribed return codes (meaning: you may see "I/O Timeout" instead of "Resource already locked"),
     - the length of the timeouts (timeouts may be significantly longer than specified)
-    - the sequencing: some devices, once already locked, will allow `open_resource(..no_lock)`
+    - the sequencing: some devices, once already locked, will allow `open_resource`
       to succeed (as they should per VXI-11 spec RULE B.6.6), but others don't.
 
     If you are debugging locking issues, note that NI-Visa supports
     the lock-on-open method, but underneath uses the lock-after-open method, and, 
     after having established a lock, handles the locking internally without addressing
     the instrument.
-
-    **VXI-11** also technically supports a third way of locking, which is to request a lock 
-    per operation (read/write/clear/...). That is not supported by VISA VPP-4.3, 
-    therefore neither by PyVISA, no matter the chosen backend.
 
 
 .. _PySerial: https://pythonhosted.org/pyserial/

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -151,15 +151,35 @@ For the TCP transports (``TCPIP::INSTR``, both VXI-11 and HiSLIP, and
 ``TCPIP::SOCKET``), ``open_timeout`` bounds how long PyVISA-py will spend
 establishing the connection::
 
+Without a lock on open:
+
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')
     >>> # allow 10 s to reach an instrument across a slow link
     >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000)
 
-If you do not pass one, the connection attempt is given 2000 ms.  An
+If you do not specify ``open_timeout``, the connection attempt is given 2000 ms.  An
 ``open_timeout`` of 0 selects that same default rather than meaning "give up
 immediately", since ``ResourceManager.open_resource`` passes 0 whenever you
 omit the argument.
+
+With a lock on open:
+
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> # allow 10 s to reach an instrument across a slow link, 
+    >>> # and 10 s to acquire a lock on the instrument
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000, 
+    >>>                         access_mode=pyvisa.constants.AccessModes.exclusive_lock)
+
+The connection will be established with the same timeout handling as above,
+but will then try to open a link with a lock timeout also governed by ``open_timeout``.
+That lock request will succeed if the instrument grants it within this period.
+An ``open_timeout`` of 0 or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
+while None means "10 seconds", and ``VI_TMO_INFINITE`` means "wait indefinitely".
+
+If you want better control over the lock timing, open without a lock and then 
+use ``inst.lock_excl(timeout=timeout)``.
 
 .. note::
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -165,19 +165,17 @@ omit the argument.
 Locking
 -------
 
-There are different types of locks with VISA:
+**PyVISA-Py only supports exclusive locking, and only on VXI-11. Shared locks are not supported.** 
 
-- Exclusive lock: only one session can access the instrument at a time
-- Shared lock: multiple sessions can access the instrument simultaneously
+Socket instruments (``TCPIP::SOCKET``) do not support locking.
+HiSLIP instruments (``TCPIP::hislip0``) could support locking, but PyVISA-Py does not yet implement this feature.
 
-**Pyvisa-py does not support shared locks.**
-
-There are two ways of using **exclusive** locking on an instrument session via pyvisa:
+There are two ways of using exclusive locking on an instrument session via pyvisa:
 
 - lock on open
 - lock after open
 
-Lock on open is done via the ``access_mode`` argument to ``ResourceManager.open_resource``.  The
+"Lock on open" is done via the ``access_mode`` argument to ``ResourceManager.open_resource``.  The
 default is ``pyvisa.constants.AccessModes.no_lock``, which does not request a lock.
 
     >>> import pyvisa
@@ -193,7 +191,7 @@ That lock request will succeed if the instrument grants it within this period.
 An ``open_timeout`` of 0 or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
 while None means "10 seconds", and ``VI_TMO_INFINITE`` means "wait indefinitely".
 
-If you want better control over the different timeout settings, lock after the open:
+If you want better control over the different timeout settings, use "lock after open":
 
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')
@@ -204,16 +202,22 @@ If you want better control over the different timeout settings, lock after the o
 
 .. note::
 
-    **Portability:** Exclusive locking should work consistently across different 
-    VISA implementations.
+    **Portability:** Exclusive locking should work, but some devices (even recent ones from the big brands),
+    and also some of the VISA backends, use a certain amount of liberties. Do not expect respect of the following:
+
+    - the prescribed return codes (meaning: you may see "I/O Timeout" instead of "Resource already locked"),
+    - the length of the timeouts (timeouts may be significantly longer than specified)
+    - the sequencing: some devices, once already locked, will allow `open_resource(..no_lock)`
+      to succeed (as they should per VXI-11 spec RULE B.6.6), but others don't.
+
     If you are debugging locking issues, note that NI-Visa supports
     the lock-on-open method, but underneath uses the lock-after-open method, and, 
     after having established a lock, handles the locking internally without addressing
     the instrument.
 
-    **VXI-11:** VXI-11 supports a third way of locking, which is to request a lock 
+    **VXI-11** also technically supports a third way of locking, which is to request a lock 
     per operation (read/write/clear/...). That is not supported by VISA VPP-4.3, 
-    therefore neither by pyvisa, no matter the chosen backend.
+    therefore neither by PyVISA, no matter the chosen backend.
 
 
 .. _PySerial: https://pythonhosted.org/pyserial/

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -233,19 +233,18 @@ in case another program or session has locked it, you must choose one of the fol
     that already has a lock: they should reply immediately with ``VI_ERROR_RSRC_LOCKED``.
     However, in practice this is not always the case, and some instruments take quite some liberties with it.    
 
-    ``pyvisa.constants.VI_KTATTR_LOCKWAIT`` may not be available yet in PyVISA. In that case, you could do this:
+    ``VI_KTATTR_LOCKWAIT`` may not be visible in the ``pyvisa/constants.py`` file,
+    but it is set by PyVISA-Py. Just use as follows:
 
     >>> import pyvisa
+    >>> import pyvisa.constants
     >>> rm = pyvisa.ResourceManager('@py')
     >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR')
     >>>
-    >>> # Define the raw hex constant for VI_KTATTR_LOCKWAIT
-    >>> VI_KTATTR_LOCKWAIT = 0x0FFF002BL
-    >>>
     >>> # Set lockwait to True (VI_TRUE = 1)
-    >>> inst.set_attribute(VI_KTATTR_LOCKWAIT, 1)
+    >>> inst.set_visa_attribute(pyvisa.constants.VI_KTATTR_LOCKWAIT, 1)  # type: ignore[attr-defined]
     >>> # Read back the attribute value
-    >>> lockwait_val = inst.get_attribute(VI_KTATTR_LOCKWAIT)
+    >>> lockwait_val = inst.get_visa_attribute(pyvisa.constants.VI_KTATTR_LOCKWAIT) # type: ignore[attr-defined]
     >>> print("Lockwait state:", lockwait_val)
     >>>
     >>> # Do your operations

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -112,9 +112,8 @@ if you want to read more about connection dropping in docker containers)
 Why not using LibreVISA?
 ------------------------
 
-LibreVISA_ is still young and appears mostly unmaintained at this
-point (latest release is from 2013).
-However, you can already use it with the IVI backend as it has the same API.
+LibreVISA_ is unmaintained at this point (latest release is from 2013).
+However, you can use it with the IVI backend as it has the same API.
 We think that PyVISA-py is easier to hack and we can quickly reach feature parity
 with other IVI-VISA implementation for message-based instruments.
 
@@ -173,7 +172,7 @@ There are different types of locks with VISA:
 
 **Pyvisa-py does not support shared locks.**
 
-There are two ways of using exclusive locking an instrument session via pyvisa:
+There are two ways of using **exclusive** locking on an instrument session via pyvisa:
 
 - lock on open
 - lock after open
@@ -198,8 +197,8 @@ If you want better control over the different timeout settings, lock after the o
 
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')
-    >>> # allow 2 s to reach an instrument, 
-    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=2000)
+    >>> # allow 3 s to reach the instrument
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=3000)
     >>> # and then try to acquire a lock on the instrument with a 10 s timeout
     >>> inst.lock_excl(timeout=10000) 
 
@@ -214,7 +213,7 @@ If you want better control over the different timeout settings, lock after the o
 
     **VXI-11:** VXI-11 supports a third way of locking, which is to request a lock 
     per operation (read/write/clear/...). That is not supported by VISA VPP-4.3, 
-    neither by pyvisa, no matter the VISA implementation.
+    therefore neither by pyvisa, no matter the chosen backend.
 
 
 .. _PySerial: https://pythonhosted.org/pyserial/

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -183,7 +183,7 @@ If another session has a lock, another client will not be able to communicate wi
 the instrument. Either ``open_resource`` will fail, either ``read`` / ``write`` / ``query`` /... 
 operations will fail. 
 The related error codes in that case are:
-``VI_ERROR_RSRC_LOCKED`` (as it should), or ``VI_ERROR_TMO`` or ``VI_ERROR_RSRC_BUSY``.
+``VI_ERROR_RSRC_LOCKED`` (as it should), or ``VI_ERROR_TMO`` or ``VI_ERROR_RSRC_BUSY`` or ``VI_ERROR_IO``.
 
 There are two ways of using exclusive locking on an instrument session via pyvisa:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -129,29 +129,12 @@ By using PyVISA as a frontend to many backends, we abstract these things
 from higher level applications.
 
 
-Why is my Ethernet instrument not working?
-------------------------------------------
-
-Some instruments, such as the Rigol DM3068 Digital Multimeter,
-expect a non-default parameter in order to communicate successfully over Ethernet.
-In the case of the DM3068, the VXI-11 lock timeout must be set to zero:
-
-    >>> import pyvisa
-    >>> rm = pyvisa.ResourceManager('@py')
-    >>> dm3068 = rm.open_resource('TCPIP::rigol-dm3068-hostname::INSTR')
-    >>> # default lock_timeout is still 10000ms at this point
-    >>> rm.visalib.sessions[dm3068.session].lock_timeout = 0
-    >>> # can now communicate successfully with the DM3068
-
-
 What does ``open_timeout`` control?
 -----------------------------------
 
 For the TCP transports (``TCPIP::INSTR``, both VXI-11 and HiSLIP, and
 ``TCPIP::SOCKET``), ``open_timeout`` bounds how long PyVISA-py will spend
 establishing the connection::
-
-Without a lock on open:
 
     >>> import pyvisa
     >>> rm = pyvisa.ResourceManager('@py')
@@ -162,24 +145,6 @@ If you do not specify ``open_timeout``, the connection attempt is given 2000 ms.
 ``open_timeout`` of 0 selects that same default rather than meaning "give up
 immediately", since ``ResourceManager.open_resource`` passes 0 whenever you
 omit the argument.
-
-With a lock on open:
-
-    >>> import pyvisa
-    >>> rm = pyvisa.ResourceManager('@py')
-    >>> # allow 10 s to reach an instrument across a slow link, 
-    >>> # and 10 s to acquire a lock on the instrument
-    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000, 
-    >>>                         access_mode=pyvisa.constants.AccessModes.exclusive_lock)
-
-The connection will be established with the same timeout handling as above,
-but will then try to open a link with a lock timeout also governed by ``open_timeout``.
-That lock request will succeed if the instrument grants it within this period.
-An ``open_timeout`` of 0 or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
-while None means "10 seconds", and ``VI_TMO_INFINITE`` means "wait indefinitely".
-
-If you want better control over the lock timing, open without a lock and then 
-use ``inst.lock_excl(timeout=timeout)``.
 
 .. note::
 
@@ -197,9 +162,59 @@ use ``inst.lock_excl(timeout=timeout)``.
         implementation should behave as if the timeout parameter is the VISA
         default timeout value of 2000 milliseconds.
 
-    The trade-off is that ``VI_TMO_IMMEDIATE`` can no longer request "never
-    wait on a lock".  Set ``lock_timeout`` on the session for that, as in the
-    DM3068 example above.
+
+Locking
+-------
+
+There are different types of locks with VISA:
+
+- Exclusive lock: only one session can access the instrument at a time
+- Shared lock: multiple sessions can access the instrument simultaneously
+
+**Pyvisa-py does not support shared locks.**
+
+There are two ways of using exclusive locking an instrument session via pyvisa:
+
+- lock on open
+- lock after open
+
+Lock on open is done via the ``access_mode`` argument to ``ResourceManager.open_resource``.  The
+default is ``pyvisa.constants.AccessModes.no_lock``, which does not request a lock.
+
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> # allow 10 s to reach an instrument across a slow link, 
+    >>> # and 10 s to acquire a lock on the instrument
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=10000, 
+    >>>                         access_mode=pyvisa.constants.AccessModes.exclusive_lock)
+
+The connection will be established with the same timeout handling as mentioned above,
+but will then try to open a link with a lock timeout also governed by ``open_timeout``.
+That lock request will succeed if the instrument grants it within this period.
+An ``open_timeout`` of 0 or ``VI_TMO_IMMEDIATE`` there means: "give up immediately", 
+while None means "10 seconds", and ``VI_TMO_INFINITE`` means "wait indefinitely".
+
+If you want better control over the different timeout settings, lock after the open:
+
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> # allow 2 s to reach an instrument, 
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR', open_timeout=2000)
+    >>> # and then try to acquire a lock on the instrument with a 10 s timeout
+    >>> inst.lock_excl(timeout=10000) 
+
+.. note::
+
+    **Portability:** Exclusive locking should work consistently across different 
+    VISA implementations.
+    If you are debugging locking issues, note that NI-Visa supports
+    the lock-on-open method, but underneath uses the lock-after-open method, and, 
+    after having established a lock, handles the locking internally without addressing
+    the instrument.
+
+    **VXI-11:** VXI-11 supports a third way of locking, which is to request a lock 
+    per operation (read/write/clear/...). That is not supported by VISA VPP-4.3, 
+    neither by pyvisa, no matter the VISA implementation.
 
 
 .. _PySerial: https://pythonhosted.org/pyserial/

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -228,6 +228,24 @@ in case another program or session has locked it, you must choose one of the fol
 
     The default value of ``VI_KTATTR_LOCKWAIT`` is ``FALSE/0`` (do not wait).
 
+    ``VI_KTATTR_LOCKWAIT`` may not be available yet in pyvisa. In that case, you could do this:
+
+    >>> import pyvisa
+    >>> rm = pyvisa.ResourceManager('@py')
+    >>> inst = rm.open_resource('TCPIP::192.168.1.100::INSTR')
+    >>>
+    >>> # Define the raw hex constant for VI_KTATTR_LOCKWAIT
+    >>> VI_KTATTR_LOCKWAIT = 0x0FFF002BL
+    >>>
+    >>> # Set lockwait to True (VI_TRUE = 1)
+    >>> inst.set_attribute(VI_KTATTR_LOCKWAIT, 1)
+    >>> # Read back the attribute value
+    >>> lockwait_val = inst.get_attribute(VI_KTATTR_LOCKWAIT)
+    >>> print("Lockwait state:", lockwait_val)
+    >>>
+    >>> # Do your operations
+
+
 Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``VI_KTATTR_LOCKWAIT``.
 
 ``lock_timeout`` from previous PyVISA-Py versions has been removed.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -219,16 +219,18 @@ If you have not locked the instrument, and want to control the behaviour of your
 in case another program or session has locked it, you must choose one of the following methods:
 
 - Request a lock via ``inst.lock_excl()``. This is the most portable. See above.
-- Configure the lock timeout via the PyVISA-Py specific ``rm.visalib.sessions[inst.session].lock_timeout``.  
+- Configure the lock timeout via the Keysight and PyVISA-Py specific attribute ``VI_KTATTR_LOCKWAIT`` (0x0FFF002B)
 
-    When using ``lock_timeout`` on an instrument that is locked by another session:
+    When using ``VI_KTATTR_LOCKWAIT`` on an instrument that is locked by another session:
 
     - If ``0``, operations will fail immediately. 
-    - If set to a positive value, operations will wait for that many milliseconds for the lock to be removed before failing. 
+    - If ``1``, operations will wait for ``inst.timeout`` for the lock to be removed before failing. 
 
-    The default value of ``lock_timeout`` is ``0`` or ``VI_TMO_IMMEDIATE`` (do not wait).
+    The default value of ``VI_KTATTR_LOCKWAIT`` is ``FALSE/0`` (do not wait).
 
-Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``lock_timeout``.
+Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``VI_KTATTR_LOCKWAIT``.
+
+``lock_timeout`` from previous PyVISA-Py versions has been removed.
 
 Event handling is not affected by locking. 
 

--- a/pyvisa_py/attributes.py
+++ b/pyvisa_py/attributes.py
@@ -9,6 +9,7 @@ For additional information and VISA attributes see pyvisa.constants
 
 from pyvisa import constants
 from pyvisa.attributes import AttrVI_ATTR_TCPIP_KEEPALIVE as former_keepalive
+from pyvisa.attributes import BooleanAttribute
 
 
 class AttrVI_ATTR_TCPIP_KEEPALIVE(former_keepalive):
@@ -29,3 +30,24 @@ class AttrVI_ATTR_TCPIP_KEEPALIVE(former_keepalive):
         (constants.InterfaceType.tcpip, "INSTR"),
         (constants.InterfaceType.vicp, "INSTR"),
     ]
+
+
+# force the definition of the attribute in pyvisa.constants to be able to use it in pyvisa-py
+if not hasattr(constants, "VI_KTATTR_LOCKWAIT"):
+    constants.VI_KTATTR_LOCKWAIT = 0x0FFF002B
+    constants.ResourceAttribute.lockwait = constants.VI_KTATTR_LOCKWAIT
+
+    class AttrVI_KTATTR_LOCKWAIT(BooleanAttribute):
+        resources = [
+            (constants.InterfaceType.tcpip, "INSTR"),
+        ]
+
+        py_name = ""
+
+        visa_name = "VI_KTATTR_LOCKWAIT"
+
+        visa_type = "ViBoolean"
+
+        default = False
+
+        read, write, local = True, True, True

--- a/pyvisa_py/attributes.py
+++ b/pyvisa_py/attributes.py
@@ -8,8 +8,10 @@ For additional information and VISA attributes see pyvisa.constants
 """
 
 from pyvisa import constants
-from pyvisa.attributes import AttrVI_ATTR_TCPIP_KEEPALIVE as former_keepalive
-from pyvisa.attributes import BooleanAttribute
+from pyvisa.attributes import (
+    AttrVI_ATTR_TCPIP_KEEPALIVE as former_keepalive,
+    BooleanAttribute,
+)
 
 
 class AttrVI_ATTR_TCPIP_KEEPALIVE(former_keepalive):

--- a/pyvisa_py/attributes.py
+++ b/pyvisa_py/attributes.py
@@ -34,8 +34,8 @@ class AttrVI_ATTR_TCPIP_KEEPALIVE(former_keepalive):
 
 # force the definition of the attribute in pyvisa.constants to be able to use it in pyvisa-py
 if not hasattr(constants, "VI_KTATTR_LOCKWAIT"):
-    constants.VI_KTATTR_LOCKWAIT = 0x0FFF002B
-    constants.ResourceAttribute.lockwait = constants.VI_KTATTR_LOCKWAIT
+    constants.VI_KTATTR_LOCKWAIT = 0x0FFF002B  # type: ignore[attr-defined]
+    constants.ResourceAttribute.lockwait = constants.VI_KTATTR_LOCKWAIT  # type: ignore[attr-defined]
 
     class AttrVI_KTATTR_LOCKWAIT(BooleanAttribute):
         resources = [

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -42,6 +42,7 @@ class GPIBSessionDispatch(Session):
         resource_manager_session: VISARMSession,
         resource_name: str,
         parsed=None,
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock,
         open_timeout: int | None = None,
     ) -> Session:
         newcls: Type
@@ -54,7 +55,7 @@ class GPIBSessionDispatch(Session):
         else:
             newcls = GPIBSession
 
-        return newcls(resource_manager_session, resource_name, parsed, open_timeout)
+        return newcls(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
 
     @staticmethod
     def list_resources() -> List[str]:

--- a/pyvisa_py/gpib.py
+++ b/pyvisa_py/gpib.py
@@ -55,7 +55,9 @@ class GPIBSessionDispatch(Session):
         else:
             newcls = GPIBSession
 
-        return newcls(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
+        return newcls(
+            resource_manager_session, resource_name, parsed, access_mode, open_timeout
+        )
 
     @staticmethod
     def list_resources() -> List[str]:

--- a/pyvisa_py/highlevel.py
+++ b/pyvisa_py/highlevel.py
@@ -194,7 +194,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         )
 
         try:
-            sess = cls(session, resource_name, parsed, open_timeout)
+            sess = cls(session, resource_name, parsed, access_mode, open_timeout)
         except OpenError as e:
             return VISASession(0), self.handle_return_value(None, e.error_code)
 

--- a/pyvisa_py/prologix.py
+++ b/pyvisa_py/prologix.py
@@ -55,9 +55,10 @@ class _PrologixIntfcSession(Session):  # pylint: disable=W0223
         resource_manager_session: VISARMSession,
         resource_name: str,
         parsed: rname.ResourceName | None = None,
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock,
         open_timeout: int | None = None,
     ) -> None:
-        super().__init__(resource_manager_session, resource_name, parsed, open_timeout)
+        super().__init__(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
 
         # store this instance in the dictionary of Prologix interfaces
         self.boards[self.parsed.board] = self

--- a/pyvisa_py/prologix.py
+++ b/pyvisa_py/prologix.py
@@ -58,7 +58,9 @@ class _PrologixIntfcSession(Session):  # pylint: disable=W0223
         access_mode: constants.AccessModes = constants.AccessModes.no_lock,
         open_timeout: int | None = None,
     ) -> None:
-        super().__init__(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
+        super().__init__(
+            resource_manager_session, resource_name, parsed, access_mode, open_timeout
+        )
 
         # store this instance in the dictionary of Prologix interfaces
         self.boards[self.parsed.board] = self

--- a/pyvisa_py/sessions.py
+++ b/pyvisa_py/sessions.py
@@ -301,12 +301,14 @@ class Session(metaclass=abc.ABCMeta):
         resource_manager_session: VISARMSession,
         resource_name: str,
         parsed: Optional[rname.ResourceName] = None,
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock,
         open_timeout: Optional[int] = None,
     ) -> None:
         if parsed is None:
             parsed = rname.parse_resource_name(resource_name)
 
         self.parsed = parsed
+        self.access_mode = access_mode
         self.open_timeout = open_timeout
 
         #: Used as a place holder for the object doing the lowlevel communication.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -634,7 +634,7 @@ class TCPIPInstrVxi11(Session):
 
         # add the Keysight and PyVISA-Py specific lock wait attribute, which is a boolean that
         # controls whether to wait for the lock or not
-        self.attrs[ResourceAttribute.lockwait] = constants.VI_FALSE
+        self.attrs[ResourceAttribute.lockwait] = constants.VI_FALSE  # type: ignore[attr-defined]
 
     def close(self) -> StatusCode:
         self._stop_event_monitor()
@@ -755,7 +755,7 @@ class TCPIPInstrVxi11(Session):
         # Do as Keysight does it:
 
         lock_timeout = constants.VI_TMO_IMMEDIATE
-        if self.attrs[ResourceAttribute.lockwait] == constants.VI_TRUE:
+        if self.attrs[ResourceAttribute.lockwait] == constants.VI_TRUE:  # type: ignore[attr-defined]
             # Get the timeout as cleaned up by the upper layers
             lock_timeout = self._io_timeout  # is in ms
             if lock_timeout != constants.VI_TMO_IMMEDIATE:
@@ -944,8 +944,8 @@ class TCPIPInstrVxi11(Session):
         if attribute == constants.VI_ATTR_TCPIP_KEEPALIVE:
             return self.keepalive, StatusCode.success
 
-        if attribute == constants.VI_KTATTR_LOCKWAIT:
-            return self.attrs[ResourceAttribute.lockwait], StatusCode.success
+        if attribute == constants.VI_KTATTR_LOCKWAIT:  # type: ignore[attr-defined]
+            return self.attrs[ResourceAttribute.lockwait], StatusCode.success  # type: ignore[attr-defined]
 
         raise UnknownAttribute(attribute)
 
@@ -985,7 +985,7 @@ class TCPIPInstrVxi11(Session):
                 return StatusCode.error_nonsupported_format
             return StatusCode.success
 
-        if attribute == constants.VI_KTATTR_LOCKWAIT:
+        if attribute == constants.VI_KTATTR_LOCKWAIT:  # type: ignore[attr-defined]
             return StatusCode.success
 
         raise UnknownAttribute(attribute)

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -475,6 +475,7 @@ class TCPIPInstrVxi11(Session):
     #: Time to wait in ms before erroring with a timeout when trying to acquire a lock
     # 0 = immediate, >0 = wait for that many milliseconds
     # This is used for most operations (mainly except open_resource and lock_excl)
+    # TODO: maybe expose this as VI_ATTR_LOCK_TIMEOUT. But this is not a standard VISA attribute.
     lock_timeout: int = 0
 
     #: Unique ID of the client used to authenticate messages.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -74,6 +74,7 @@ class TCPIPInstrSession(Session):
         resource_manager_session: VISARMSession,
         resource_name: str,
         parsed=None,
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock,
         open_timeout: Optional[int] = None,
     ):
         newcls: Type
@@ -87,7 +88,7 @@ class TCPIPInstrSession(Session):
         else:
             newcls = TCPIPInstrVxi11
 
-        return newcls(resource_manager_session, resource_name, parsed, open_timeout)
+        return newcls(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
 
     @staticmethod
     def list_resources(wait_time=1.0) -> List[str]:
@@ -437,7 +438,10 @@ class Vxi11CoreClient(vxi11.CoreClient):
     """
 
     def __init__(
-        self, host: str, port: Optional[int], open_timeout: Optional[int] = None
+        self, host: str, 
+        port: Optional[int], 
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock, 
+        open_timeout: Optional[int] = None
     ) -> None:
         self._lock = threading.Lock()
         self.packer = vxi11.Vxi11Packer()
@@ -547,7 +551,7 @@ class TCPIPInstrVxi11(Session):
         else:
             port = None
         try:
-            self.interface = Vxi11CoreClient(host_address, port, self.open_timeout)
+            self.interface = Vxi11CoreClient(host_address, port, self.access_mode, self.open_timeout)
         except rpc.RPCError:
             LOGGER.exception(
                 f"Failed to open VX11 connection to {host_address} on port {port}"
@@ -558,9 +562,24 @@ class TCPIPInstrVxi11(Session):
         self.keepalive = False
         self._srq_server: vxi11.SrqInterruptTCPServer | None = None
         self._srq_lifecycle_lock = threading.Lock()
-
+        
+        if self.access_mode & constants.AccessModes.exclusive_lock:
+            access_mode_exclusive_lock = 1
+            # The below is for lock_timeout, the instrument has been opened already
+            # lock_timeout can be 0 for immediate
+            lock_timeout = self.open_timeout
+            if lock_timeout is None:
+                lock_timeout = 10000  # default lock timeout in ms. This shouldn't happen
+            if lock_timeout == constants.VI_TMO_INFINITE:
+                lock_timeout = 2**32 - 1  # This is dangerous, but hey, the caller wanted it.
+            if lock_timeout == constants.VI_TMO_IMMEDIATE:
+                lock_timeout = 0  # This is NOP, but makes the code more readable            
+        else:
+            access_mode_exclusive_lock = 0
+            lock_timeout = 0  # time is not used now.
+            
         error, link, _abort_port, max_recv_size = self.interface.create_link(
-            self.client_id, 0, self.lock_timeout, self.parsed.lan_device_name
+            self.client_id, access_mode_exclusive_lock, lock_timeout, self.parsed.lan_device_name
         )
 
         if error:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -492,7 +492,7 @@ class TCPIPInstrVxi11(Session):
     # Keysight exposes the Keysight-specific VISA ViBoolean local (per-session) attribute VI_KTATTR_LOCKWAIT
     #   When False, when already locked, immediately returns VI_ERROR_RSRC_LOCKED
     #   When True, uses lock timeout = session timeout interval. When locked and timed out, returns VI_ERROR_TMO
-    lock_timeout: int = 0
+    # lock_timeout: int = 0
 
     #: Unique ID of the client used to authenticate messages.
     client_id: int
@@ -632,6 +632,10 @@ class TCPIPInstrVxi11(Session):
             attribute = getattr(constants, "VI_ATTR_" + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
+        # add the Keysight and PyVISA-Py specific lock wait attribute, which is a boolean that
+        # controls whether to wait for the lock or not
+        self.attrs[ResourceAttribute.lockwait] = constants.VI_FALSE
+
     def close(self) -> StatusCode:
         self._stop_event_monitor()
         try:
@@ -748,12 +752,14 @@ class TCPIPInstrVxi11(Session):
                 pass
 
     def _adapt_flags_and_lock_timeout(self, flags: int) -> Tuple[int, int]:
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we derive it from self.lock_timeout.
-        lock_timeout = self.lock_timeout
-        if lock_timeout != constants.VI_TMO_IMMEDIATE:
-            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        # Do as Keysight does it:
+
+        lock_timeout = constants.VI_TMO_IMMEDIATE
+        if self.attrs[ResourceAttribute.lockwait] == constants.VI_TRUE:
+            # Get the timeout as cleaned up by the upper layers
+            lock_timeout = self._io_timeout  # is in ms
+            if lock_timeout != constants.VI_TMO_IMMEDIATE:
+                flags |= vxi11.OP_FLAG_WAIT_BLOCK
         return flags, lock_timeout
 
     def _read_status_from_reason(
@@ -938,6 +944,9 @@ class TCPIPInstrVxi11(Session):
         if attribute == constants.VI_ATTR_TCPIP_KEEPALIVE:
             return self.keepalive, StatusCode.success
 
+        if attribute == constants.VI_KTATTR_LOCKWAIT:
+            return self.attrs[ResourceAttribute.lockwait], StatusCode.success
+
         raise UnknownAttribute(attribute)
 
     def _set_attribute(
@@ -974,6 +983,9 @@ class TCPIPInstrVxi11(Session):
                 self.keepalive = False
             else:
                 return StatusCode.error_nonsupported_format
+            return StatusCode.success
+
+        if attribute == constants.VI_KTATTR_LOCKWAIT:
             return StatusCode.success
 
         raise UnknownAttribute(attribute)
@@ -1114,6 +1126,7 @@ class TCPIPInstrVxi11(Session):
         # value is in milliseconds,
         # and can be VI_TMO_INFINITE (2**32 - 1) or VI_TMO_IMMEDIATE (0)
         self._io_timeout = value
+        # self.timeout comes from the superclass, is in seconds, and can be None (infinite) or 0 (immediate)
         if value == constants.VI_TMO_INFINITE:
             self.timeout = None
         elif value == constants.VI_TMO_IMMEDIATE:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -798,8 +798,7 @@ class TCPIPInstrVxi11(Session):
         if self.attrs[ResourceAttribute.lockwait] == constants.VI_TRUE:  # type: ignore[attr-defined]
             # Get the timeout as cleaned up by the upper layers
             lock_timeout = self._io_timeout  # is in ms
-            if lock_timeout != constants.VI_TMO_IMMEDIATE:
-                flags |= vxi11.OP_FLAG_WAIT_BLOCK
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
         return flags, lock_timeout
 
     def _read_status_from_reason(
@@ -981,22 +980,23 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
+        flags, lock_timeout = self._adapt_flags_and_lock_timeout(0)
         if mode in (
             constants.RENLineOperation.asrt_address,
             constants.RENLineOperation.asrt_address_llo,
         ):
             error = self.interface.device_remote(
-                self.link, 0, self.lock_timeout, self._io_timeout
+                self.link, flags, lock_timeout, self._io_timeout
             )
-            return VXI11_ERRORS_TO_VISA[error]
+            return vxi11_error_to_visa(error)
         elif mode in (
             constants.RENLineOperation.address_gtl,
             constants.RENLineOperation.deassert_gtl,
         ):
             error = self.interface.device_local(
-                self.link, 0, self.lock_timeout, self._io_timeout
+                self.link, flags, lock_timeout, self._io_timeout
             )
-            return VXI11_ERRORS_TO_VISA[error]
+            return vxi11_error_to_visa(error)
         else:
             return constants.StatusCode.error_nonsupported_operation
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -487,7 +487,11 @@ class TCPIPInstrVxi11(Session):
     #: Time to wait in ms before erroring with a timeout when trying to acquire a lock
     # 0 = immediate, >0 = wait for that many milliseconds
     # This is used for most operations (mainly except open_resource and lock_excl)
-    # TODO: maybe expose this as VI_ATTR_LOCK_TIMEOUT. But this is not a standard VISA attribute.
+    #
+    # NI-VISA and R&S VISA do not expose any of this.
+    # Keysight exposes the Keysight-specific VISA ViBoolean local (per-session) attribute VI_KTATTR_LOCKWAIT
+    #   When False, when already locked, immediately returns VI_ERROR_RSRC_LOCKED
+    #   When True, uses lock timeout = session timeout interval. When locked and timed out, returns VI_ERROR_TMO
     lock_timeout: int = 0
 
     #: Unique ID of the client used to authenticate messages.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -473,7 +473,9 @@ class TCPIPInstrVxi11(Session):
     max_recv_size: int
 
     #: Time to wait in ms before erroring with a timeout when trying to acquire a lock
-    lock_timeout: int = 10000
+    # 0 = immediate, >0 = wait for that many milliseconds
+    # This is used for most operations (mainly except open_resource and lock_excl)
+    lock_timeout: int = 0
 
     #: Unique ID of the client used to authenticate messages.
     client_id: int
@@ -764,11 +766,10 @@ class TCPIPInstrVxi11(Session):
             
         # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
         # VPP-4.3 does not provide a clear definition for it. 
-        # For now, we test if it is set and handle the flag properly, 
-        # although the flag is likely not set.
-        lock_timeout = 0
-        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = self.lock_timeout
+        # For now, we derive it from self.lock_timeout.
+        lock_timeout = self.lock_timeout
+        if lock_timeout != constants.VI_TMO_IMMEDIATE:
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
 
         suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 
@@ -858,11 +859,10 @@ class TCPIPInstrVxi11(Session):
             
             # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
             # VPP-4.3 does not provide a clear definition for it. 
-            # For now, we test if it is set and handle the flag properly, 
-            # although the flag is likely not set.
-            lock_timeout = 0
-            if flags & vxi11.OP_FLAG_WAIT_BLOCK:
-                lock_timeout = self.lock_timeout
+            # For now, we derive it from self.lock_timeout.
+            lock_timeout = self.lock_timeout
+            if lock_timeout != constants.VI_TMO_IMMEDIATE:
+                flags |= vxi11.OP_FLAG_WAIT_BLOCK
             
             while num > 0:
                 if num <= self.max_recv_size:
@@ -980,13 +980,12 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we test if it is set and handle the flag properly,
-        # although the flag is likely not set.
-        lock_timeout = 0
-        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = self.lock_timeout
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
+        # VPP-4.3 does not provide a clear definition for it. 
+        # For now, we derive it from self.lock_timeout.
+        lock_timeout = self.lock_timeout
+        if lock_timeout != constants.VI_TMO_IMMEDIATE:
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
 
         # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
@@ -1002,13 +1001,12 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we test if it is set and handle the flag properly,
-        # although the flag is likely not set.
-        lock_timeout = 0
-        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = self.lock_timeout
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
+        # VPP-4.3 does not provide a clear definition for it. 
+        # For now, we derive it from self.lock_timeout.
+        lock_timeout = self.lock_timeout
+        if lock_timeout != constants.VI_TMO_IMMEDIATE:
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
         
         error = self.interface.device_clear(
             self.link, flags, lock_timeout, self._io_timeout
@@ -1030,13 +1028,12 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we test if it is set and handle the flag properly,
-        # although the flag is likely not set.
-        lock_timeout = 0
-        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = self.lock_timeout
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
+        # VPP-4.3 does not provide a clear definition for it. 
+        # For now, we derive it from self.lock_timeout.
+        lock_timeout = self.lock_timeout
+        if lock_timeout != constants.VI_TMO_IMMEDIATE:
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
 
         error, stb = self.interface.device_read_stb(
             self.link, flags, lock_timeout, self._io_timeout

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -879,6 +879,7 @@ class TCPIPInstrVxi11(Session):
                     return offset, StatusCode.error_timeout
 
                 elif error or size < len(block):
+                    # TODO: translate the proper error codes, especially 11 etc, everywhere
                     return offset, StatusCode.error_io
 
                 offset += size

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -750,6 +750,11 @@ class TCPIPInstrVxi11(Session):
             flags = vxi11.OP_FLAG_TERMCHAR_SET
         else:
             term_char = flags = 0
+            
+        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
+        lock_timeout = self.lock_timeout
+        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = 0
 
         suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 
@@ -790,7 +795,7 @@ class TCPIPInstrVxi11(Session):
                 self.link,
                 chunk_length,
                 chunk_timeout,
-                self.lock_timeout,
+                lock_timeout,
                 flags,
                 term_char,
             )
@@ -836,7 +841,12 @@ class TCPIPInstrVxi11(Session):
             flags = 0
             num = len(data)
             offset = 0
-
+            
+            # TODO determine if OP_FLAG_WAIT_BLOCK is needed
+            lock_timeout = self.lock_timeout
+            if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
+                lock_timeout = 0
+            
             while num > 0:
                 if num <= self.max_recv_size:
                     flags |= vxi11.OP_FLAG_END
@@ -844,7 +854,7 @@ class TCPIPInstrVxi11(Session):
                 block = data[offset : offset + self.max_recv_size]
 
                 error, size = self.interface.device_write(
-                    self.link, self._io_timeout, self.lock_timeout, flags, block
+                    self.link, self._io_timeout, lock_timeout, flags, block
                 )
 
                 if error == vxi11.ErrorCodes.io_timeout:
@@ -952,9 +962,15 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
+        flags = 0
+        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
+        lock_timeout = self.lock_timeout
+        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = 0
+
         # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
-            self.link, 0, self.lock_timeout, self._io_timeout
+            self.link, flags, lock_timeout, self._io_timeout
         )
 
         return VXI11_ERRORS_TO_VISA[error]
@@ -965,8 +981,13 @@ class TCPIPInstrVxi11(Session):
         Corresponds to viClear function of the VISA library.
 
         """
+        flags = 0
+        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
+        lock_timeout = self.lock_timeout
+        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = 0        
         error = self.interface.device_clear(
-            self.link, 0, self.lock_timeout, self._io_timeout
+            self.link, flags, lock_timeout, self._io_timeout
         )
 
         return VXI11_ERRORS_TO_VISA[error]
@@ -984,8 +1005,14 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
+        flags = 0
+        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
+        lock_timeout = self.lock_timeout
+        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = 0
+
         error, stb = self.interface.device_read_stb(
-            self.link, 0, self.lock_timeout, self._io_timeout
+            self.link, flags, lock_timeout, self._io_timeout
         )
 
         return stb, VXI11_ERRORS_TO_VISA[error]
@@ -1034,11 +1061,11 @@ class TCPIPInstrVxi11(Session):
         # lock is free. If the flag is not set, device_lock SHALL terminate with
         # error set to 11, device locked by another link.
         
-        # The waitlock flag is the only flag. It is 0x1
-        if timeout == constants.VI_TMO_IMMEDIATE:
-            flags = 0x0  # don't wait for lock
-        else:
-            flags = 0x1  # wait for lock
+        flags = 0
+        # The waitlock flag is the only flag used here
+        if timeout != constants.VI_TMO_IMMEDIATE:
+            flags = vxi11.OP_FLAG_WAIT_BLOCK
+            
         error = self.interface.device_lock(self.link, flags, timeout)
 
         return "", VXI11_ERRORS_TO_VISA[error]

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -64,6 +64,7 @@ VXI11_ERRORS_TO_VISA = {
     29: StatusCode.error_window_already_mapped,  # channel_already_established
 }
 
+
 def vxi11_error_to_visa(error_code: int) -> StatusCode:
     """Translate a VXI-11 return code into a VISA status code.
 
@@ -96,7 +97,9 @@ class TCPIPInstrSession(Session):
         else:
             newcls = TCPIPInstrVxi11
 
-        return newcls(resource_manager_session, resource_name, parsed, access_mode, open_timeout)
+        return newcls(
+            resource_manager_session, resource_name, parsed, access_mode, open_timeout
+        )
 
     @staticmethod
     def list_resources(wait_time=1.0) -> List[str]:
@@ -446,10 +449,11 @@ class Vxi11CoreClient(vxi11.CoreClient):
     """
 
     def __init__(
-        self, host: str, 
-        port: Optional[int], 
-        access_mode: constants.AccessModes = constants.AccessModes.no_lock, 
-        open_timeout: Optional[int] = None
+        self,
+        host: str,
+        port: Optional[int],
+        access_mode: constants.AccessModes = constants.AccessModes.no_lock,
+        open_timeout: Optional[int] = None,
     ) -> None:
         self._lock = threading.Lock()
         self.packer = vxi11.Vxi11Packer()
@@ -562,7 +566,9 @@ class TCPIPInstrVxi11(Session):
         else:
             port = None
         try:
-            self.interface = Vxi11CoreClient(host_address, port, self.access_mode, self.open_timeout)
+            self.interface = Vxi11CoreClient(
+                host_address, port, self.access_mode, self.open_timeout
+            )
         except rpc.RPCError:
             LOGGER.exception(
                 f"Failed to open VX11 connection to {host_address} on port {port}"
@@ -573,33 +579,37 @@ class TCPIPInstrVxi11(Session):
         self.keepalive = False
         self._srq_server: vxi11.SrqInterruptTCPServer | None = None
         self._srq_lifecycle_lock = threading.Lock()
-        
+
         # RULE B.6.6:
         # The operation of create_link SHALL ignore locks if lockDevice is false.
         # RULE B.6.7:
         # If lockDevice is true and the lock is not freed after at least lock_timeout milliseconds, create_link
         # SHALL terminate without creating a link and return with error set to 11, device locked by another link.
-        
+
         # However, some devices, even from the big brands, once they are locked, will respect nothing of the above.
-        # If there is already a lock, expect some devices to act as if lockDevice is True,  
+        # If there is already a lock, expect some devices to act as if lockDevice is True,
         # to use arbitrarily longer timeouts, and expect a reply of "timeout" instead of "device locked by another link".
         # Comparable liberties are likely to be taken on device_lock().
-        
+
         if self.access_mode & constants.AccessModes.exclusive_lock:
             lock_device = 1
             # The below is for lock_timeout, the instrument has been opened already
             # lock_timeout can be 0 for immediate
             lock_timeout = self.open_timeout
             if lock_timeout is None:
-                lock_timeout = 10000  # default lock timeout in ms. This shouldn't happen
+                lock_timeout = (
+                    10000  # default lock timeout in ms. This shouldn't happen
+                )
             if lock_timeout == constants.VI_TMO_INFINITE:
-                lock_timeout = 2**32 - 1  # This is dangerous, but hey, the caller wanted it.
+                lock_timeout = (
+                    2**32 - 1
+                )  # This is dangerous, but hey, the caller wanted it.
             if lock_timeout == constants.VI_TMO_IMMEDIATE:
-                lock_timeout = 0  # This is NOP, but makes the code more readable            
+                lock_timeout = 0  # This is NOP, but makes the code more readable
         else:
             lock_device = 0
             lock_timeout = 0  # time is not used now.
-            
+
         error, link, _abort_port, max_recv_size = self.interface.create_link(
             self.client_id, lock_device, lock_timeout, self.parsed.lan_device_name
         )
@@ -772,9 +782,9 @@ class TCPIPInstrVxi11(Session):
             flags = vxi11.OP_FLAG_TERMCHAR_SET
         else:
             term_char = flags = 0
-            
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
-        # VPP-4.3 does not provide a clear definition for it. 
+
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
         # For now, we derive it from self.lock_timeout.
         lock_timeout = self.lock_timeout
         if lock_timeout != constants.VI_TMO_IMMEDIATE:
@@ -863,14 +873,14 @@ class TCPIPInstrVxi11(Session):
             flags = 0
             num = len(data)
             offset = 0
-            
-            # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
-            # VPP-4.3 does not provide a clear definition for it. 
+
+            # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+            # VPP-4.3 does not provide a clear definition for it.
             # For now, we derive it from self.lock_timeout.
             lock_timeout = self.lock_timeout
             if lock_timeout != constants.VI_TMO_IMMEDIATE:
                 flags |= vxi11.OP_FLAG_WAIT_BLOCK
-            
+
             while num > 0:
                 if num <= self.max_recv_size:
                     flags |= vxi11.OP_FLAG_END
@@ -984,8 +994,8 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
-        # VPP-4.3 does not provide a clear definition for it. 
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
         # For now, we derive it from self.lock_timeout.
         lock_timeout = self.lock_timeout
         if lock_timeout != constants.VI_TMO_IMMEDIATE:
@@ -1005,13 +1015,13 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
-        # VPP-4.3 does not provide a clear definition for it. 
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
         # For now, we derive it from self.lock_timeout.
         lock_timeout = self.lock_timeout
         if lock_timeout != constants.VI_TMO_IMMEDIATE:
             flags |= vxi11.OP_FLAG_WAIT_BLOCK
-        
+
         error = self.interface.device_clear(
             self.link, flags, lock_timeout, self._io_timeout
         )
@@ -1032,8 +1042,8 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
-        # VPP-4.3 does not provide a clear definition for it. 
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
         # For now, we derive it from self.lock_timeout.
         lock_timeout = self.lock_timeout
         if lock_timeout != constants.VI_TMO_IMMEDIATE:
@@ -1080,20 +1090,20 @@ class TCPIPInstrVxi11(Session):
         # TODO: shared lock is not implemented
         if lock_type == constants.Lock.shared:
             return "", StatusCode.error_nonsupported_operation
-        
+
         # The only remaining lock type is exclusive lock
-        
+
         # RULE B.6.74:
         # If some other link has the lock, device_lock SHALL examine the waitlock
         # flag in flags. If the flag is set, device_lock SHALL block until the
         # lock is free. If the flag is not set, device_lock SHALL terminate with
         # error set to 11, device locked by another link.
-        
+
         flags = 0
         # The waitlock flag is the only flag used here
         if timeout != constants.VI_TMO_IMMEDIATE:
             flags = vxi11.OP_FLAG_WAIT_BLOCK
-            
+
         error = self.interface.device_lock(self.link, flags, timeout)
 
         return "", vxi11_error_to_visa(error)

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -50,7 +50,7 @@ except ImportError:
 VXI11_ERRORS_TO_VISA = {
     0: StatusCode.success,  # no_error
     1: StatusCode.error_invalid_format,  # syntax_error
-    3: StatusCode.error_connection_lost,  # device_no_accessible
+    3: StatusCode.error_connection_lost,  # device_not_accessible
     4: StatusCode.error_invalid_access_key,  # invalid_link_identifier
     5: StatusCode.error_invalid_parameter,  # parameter_error
     6: StatusCode.error_handler_not_installed,  # channel_not_established
@@ -63,6 +63,14 @@ VXI11_ERRORS_TO_VISA = {
     23: StatusCode.error_abort,  # abort
     29: StatusCode.error_window_already_mapped,  # channel_already_established
 }
+
+def vxi11_error_to_visa(error_code: int) -> StatusCode:
+    """Translate a VXI-11 return code into a VISA status code.
+
+    Unknown VXI-11 error codes are translated to ``VI_ERROR_IO`` because
+    VISA has no standard status code for them.
+    """
+    return VXI11_ERRORS_TO_VISA.get(int(error_code), StatusCode.error_io)
 
 
 @Session.register(constants.InterfaceType.tcpip, "INSTR")
@@ -661,7 +669,7 @@ class TCPIPInstrVxi11(Session):
                     server.sock.close()
                 except Exception:
                     pass
-                return StatusCode.error_nonsupported_operation
+                return vxi11_error_to_visa(error)
 
             error = self.interface.device_enable_srq(self.link, True, b"srq")
             if error:
@@ -674,7 +682,7 @@ class TCPIPInstrVxi11(Session):
                     server.sock.close()
                 except Exception:
                     pass
-                return StatusCode.error_io
+                return vxi11_error_to_visa(error)
 
             with self._event_state._lock:
                 if (
@@ -816,10 +824,8 @@ class TCPIPInstrVxi11(Session):
                 term_char,
             )
 
-            if error == vxi11.ErrorCodes.io_timeout:
-                return bytes(read_data), StatusCode.error_timeout
-            elif error:
-                return bytes(read_data), StatusCode.error_io
+            if error:
+                return bytes(read_data), vxi11_error_to_visa(error)
 
             read_data.extend(data)
             count -= len(data)
@@ -875,12 +881,8 @@ class TCPIPInstrVxi11(Session):
                     self.link, self._io_timeout, lock_timeout, flags, block
                 )
 
-                if error == vxi11.ErrorCodes.io_timeout:
-                    return offset, StatusCode.error_timeout
-
-                elif error or size < len(block):
-                    # TODO: translate the proper error codes, especially 11 etc, everywhere
-                    return offset, StatusCode.error_io
+                if error or size < len(block):
+                    return offset, vxi11_error_to_visa(error)
 
                 offset += size
                 num -= size
@@ -994,7 +996,7 @@ class TCPIPInstrVxi11(Session):
             self.link, flags, lock_timeout, self._io_timeout
         )
 
-        return VXI11_ERRORS_TO_VISA[error]
+        return vxi11_error_to_visa(error)
 
     def clear(self) -> StatusCode:
         """Clears a device.
@@ -1014,7 +1016,7 @@ class TCPIPInstrVxi11(Session):
             self.link, flags, lock_timeout, self._io_timeout
         )
 
-        return VXI11_ERRORS_TO_VISA[error]
+        return vxi11_error_to_visa(error)
 
     def read_stb(self) -> Tuple[int, StatusCode]:
         """Reads a status byte of the service request.
@@ -1041,7 +1043,7 @@ class TCPIPInstrVxi11(Session):
             self.link, flags, lock_timeout, self._io_timeout
         )
 
-        return stb, VXI11_ERRORS_TO_VISA[error]
+        return stb, vxi11_error_to_visa(error)
 
     def lock(
         self,
@@ -1094,7 +1096,7 @@ class TCPIPInstrVxi11(Session):
             
         error = self.interface.device_lock(self.link, flags, timeout)
 
-        return "", VXI11_ERRORS_TO_VISA[error]
+        return "", vxi11_error_to_visa(error)
 
     def unlock(self) -> constants.StatusCode:
         """Relinquish a lock for the specified resource.
@@ -1109,7 +1111,7 @@ class TCPIPInstrVxi11(Session):
         """
         error = self.interface.device_unlock(self.link)
 
-        return VXI11_ERRORS_TO_VISA[error]
+        return vxi11_error_to_visa(error)
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
         """Sets timeout calculated value from python way to VI_ way"""

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -747,6 +747,15 @@ class TCPIPInstrVxi11(Session):
             except Exception:
                 pass
 
+    def _adapt_flags_and_lock_timeout(self, flags: int) -> Tuple[int, int]:
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
+        # For now, we derive it from self.lock_timeout.
+        lock_timeout = self.lock_timeout
+        if lock_timeout != constants.VI_TMO_IMMEDIATE:
+            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        return flags, lock_timeout
+
     def _read_status_from_reason(
         self, reason: int, suppress_end_en: bool, termchar_en: bool
     ) -> StatusCode:
@@ -796,12 +805,7 @@ class TCPIPInstrVxi11(Session):
         else:
             term_char = flags = 0
 
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we derive it from self.lock_timeout.
-        lock_timeout = self.lock_timeout
-        if lock_timeout != constants.VI_TMO_IMMEDIATE:
-            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
         suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 
@@ -889,12 +893,7 @@ class TCPIPInstrVxi11(Session):
             num = len(data)
             offset = 0
 
-            # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-            # VPP-4.3 does not provide a clear definition for it.
-            # For now, we derive it from self.lock_timeout.
-            lock_timeout = self.lock_timeout
-            if lock_timeout != constants.VI_TMO_IMMEDIATE:
-                flags |= vxi11.OP_FLAG_WAIT_BLOCK
+            flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
             while num > 0:
                 if num <= self.max_recv_size:
@@ -996,12 +995,7 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we derive it from self.lock_timeout.
-        lock_timeout = self.lock_timeout
-        if lock_timeout != constants.VI_TMO_IMMEDIATE:
-            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
         # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
@@ -1017,12 +1011,7 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we derive it from self.lock_timeout.
-        lock_timeout = self.lock_timeout
-        if lock_timeout != constants.VI_TMO_IMMEDIATE:
-            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
         error = self.interface.device_clear(
             self.link, flags, lock_timeout, self._io_timeout
@@ -1044,12 +1033,7 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
-        # VPP-4.3 does not provide a clear definition for it.
-        # For now, we derive it from self.lock_timeout.
-        lock_timeout = self.lock_timeout
-        if lock_timeout != constants.VI_TMO_IMMEDIATE:
-            flags |= vxi11.OP_FLAG_WAIT_BLOCK
+        flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
         error, stb = self.interface.device_read_stb(
             self.link, flags, lock_timeout, self._io_timeout

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -751,10 +751,13 @@ class TCPIPInstrVxi11(Session):
         else:
             term_char = flags = 0
             
-        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
-        lock_timeout = self.lock_timeout
-        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = 0
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
+        # VPP-4.3 does not provide a clear definition for it. 
+        # For now, we test if it is set and handle the flag properly, 
+        # although the flag is likely not set.
+        lock_timeout = 0
+        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = self.lock_timeout
 
         suppress_end_en, _ = self.get_attribute(ResourceAttribute.suppress_end_enabled)
 
@@ -842,10 +845,13 @@ class TCPIPInstrVxi11(Session):
             num = len(data)
             offset = 0
             
-            # TODO determine if OP_FLAG_WAIT_BLOCK is needed
-            lock_timeout = self.lock_timeout
-            if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
-                lock_timeout = 0
+            # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside. 
+            # VPP-4.3 does not provide a clear definition for it. 
+            # For now, we test if it is set and handle the flag properly, 
+            # although the flag is likely not set.
+            lock_timeout = 0
+            if flags & vxi11.OP_FLAG_WAIT_BLOCK:
+                lock_timeout = self.lock_timeout
             
             while num > 0:
                 if num <= self.max_recv_size:
@@ -963,10 +969,13 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
-        lock_timeout = self.lock_timeout
-        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = 0
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
+        # For now, we test if it is set and handle the flag properly,
+        # although the flag is likely not set.
+        lock_timeout = 0
+        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = self.lock_timeout
 
         # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
@@ -982,10 +991,14 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
-        lock_timeout = self.lock_timeout
-        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = 0        
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
+        # For now, we test if it is set and handle the flag properly,
+        # although the flag is likely not set.
+        lock_timeout = 0
+        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = self.lock_timeout
+        
         error = self.interface.device_clear(
             self.link, flags, lock_timeout, self._io_timeout
         )
@@ -1006,10 +1019,13 @@ class TCPIPInstrVxi11(Session):
 
         """
         flags = 0
-        # TODO determine if OP_FLAG_WAIT_BLOCK is needed
-        lock_timeout = self.lock_timeout
-        if not flags & vxi11.OP_FLAG_WAIT_BLOCK:
-            lock_timeout = 0
+        # TODO determine how OP_FLAG_WAIT_BLOCK could be set from the outside.
+        # VPP-4.3 does not provide a clear definition for it.
+        # For now, we test if it is set and handle the flag properly,
+        # although the flag is likely not set.
+        lock_timeout = 0
+        if flags & vxi11.OP_FLAG_WAIT_BLOCK:
+            lock_timeout = self.lock_timeout
 
         error, stb = self.interface.device_read_stb(
             self.link, flags, lock_timeout, self._io_timeout

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -563,8 +563,19 @@ class TCPIPInstrVxi11(Session):
         self._srq_server: vxi11.SrqInterruptTCPServer | None = None
         self._srq_lifecycle_lock = threading.Lock()
         
+        # RULE B.6.6:
+        # The operation of create_link SHALL ignore locks if lockDevice is false.
+        # RULE B.6.7:
+        # If lockDevice is true and the lock is not freed after at least lock_timeout milliseconds, create_link
+        # SHALL terminate without creating a link and return with error set to 11, device locked by another link.
+        
+        # However, some devices, even from the big brands, once they are locked, will respect nothing of the above.
+        # If there is already a lock, expect some devices to act as if lockDevice is True,  
+        # to use arbitrarily longer timeouts, and expect a reply of "timeout" instead of "device locked by another link".
+        # Comparable liberties are likely to be taken on device_lock().
+        
         if self.access_mode & constants.AccessModes.exclusive_lock:
-            access_mode_exclusive_lock = 1
+            lock_device = 1
             # The below is for lock_timeout, the instrument has been opened already
             # lock_timeout can be 0 for immediate
             lock_timeout = self.open_timeout
@@ -575,11 +586,11 @@ class TCPIPInstrVxi11(Session):
             if lock_timeout == constants.VI_TMO_IMMEDIATE:
                 lock_timeout = 0  # This is NOP, but makes the code more readable            
         else:
-            access_mode_exclusive_lock = 0
+            lock_device = 0
             lock_timeout = 0  # time is not used now.
             
         error, link, _abort_port, max_recv_size = self.interface.create_link(
-            self.client_id, access_mode_exclusive_lock, lock_timeout, self.parsed.lan_device_name
+            self.client_id, lock_device, lock_timeout, self.parsed.lan_device_name
         )
 
         if error:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -1022,10 +1022,24 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
-        #  TODO: lock type not implemented
-        flags = 0
-
-        error = self.interface.device_lock(self.link, flags, self.lock_timeout)
+        # TODO: shared lock is not implemented
+        if lock_type == constants.Lock.shared:
+            return "", StatusCode.error_nonsupported_operation
+        
+        # The only remaining lock type is exclusive lock
+        
+        # RULE B.6.74:
+        # If some other link has the lock, device_lock SHALL examine the waitlock
+        # flag in flags. If the flag is set, device_lock SHALL block until the
+        # lock is free. If the flag is not set, device_lock SHALL terminate with
+        # error set to 11, device locked by another link.
+        
+        # The waitlock flag is the only flag. It is 0x1
+        if timeout == constants.VI_TMO_IMMEDIATE:
+            flags = 0x0  # don't wait for lock
+        else:
+            flags = 0x1  # wait for lock
+        error = self.interface.device_lock(self.link, flags, timeout)
 
         return "", VXI11_ERRORS_TO_VISA[error]
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -524,16 +524,6 @@ class TCPIPInstrVxi11(Session):
     #: Maximum size of a chunk of data in bytes.
     max_recv_size: int
 
-    #: Time to wait in ms before erroring with a timeout when trying to acquire a lock
-    # 0 = immediate, >0 = wait for that many milliseconds
-    # This is used for most operations (mainly except open_resource and lock_excl)
-    #
-    # NI-VISA and R&S VISA do not expose any of this.
-    # Keysight exposes the Keysight-specific VISA ViBoolean local (per-session) attribute VI_KTATTR_LOCKWAIT
-    #   When False, when already locked, immediately returns VI_ERROR_RSRC_LOCKED
-    #   When True, uses lock timeout = session timeout interval. When locked and timed out, returns VI_ERROR_TMO
-    # lock_timeout: int = 0
-
     #: Unique ID of the client used to authenticate messages.
     client_id: int
 
@@ -1084,10 +1074,11 @@ class TCPIPInstrVxi11(Session):
             Return value of the library call.
 
         """
+        # protocol is ignored, VXI-11 doesn't support multiple types
+
         flags = 0
         flags, lock_timeout = self._adapt_flags_and_lock_timeout(flags)
 
-        # XXX make this nicer (either validate protocol or pass it)
         error = self.interface.device_trigger(
             self.link, flags, lock_timeout, self._io_timeout
         )

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -1,0 +1,47 @@
+"""Tests for opening VXI-11 resources."""
+
+from unittest.mock import ANY, MagicMock, patch
+
+from pyvisa import constants, rname
+
+from pyvisa_py.tcpip import TCPIPInstrVxi11
+
+
+def test_open_with_exclusive_lock_passes_lock_to_create_link():
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.exclusive_lock,
+            1234,
+        )
+
+    client.create_link.assert_called_once_with(
+        ANY, 1, 1234, parsed.lan_device_name
+    )
+    
+    
+def test_open_without_exclusive_lock_passes_lock_to_create_link():
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.no_lock,
+            1234,
+        )
+
+    client.create_link.assert_called_once_with(
+        ANY, 0, 0, parsed.lan_device_name
+    )

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -3,8 +3,9 @@
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from pyvisa import constants, rname
+from pyvisa import constants, errors, rname
 
+from pyvisa_py import highlevel
 from pyvisa_py.tcpip import TCPIPInstrVxi11
 
 
@@ -16,6 +17,7 @@ from pyvisa_py.tcpip import TCPIPInstrVxi11
         (constants.VI_TMO_INFINITE, 2**32 - 1),
     ],
 )
+
 def test_open_with_exclusive_lock_passes_lock_to_create_link(
     open_timeout, expected_lock_timeout
 ):
@@ -56,3 +58,47 @@ def test_open_without_exclusive_lock_passes_lock_to_create_link():
     client.create_link.assert_called_once_with(
         ANY, 0, 0, parsed.lan_device_name
     )
+
+
+@pytest.mark.parametrize(
+    "lock_type, timeout, expected_flags",
+    [
+        (constants.Lock.exclusive, 0, 0x0),
+        (constants.Lock.exclusive, 1000, 0x1),
+        (constants.Lock.shared, 0, None),
+        (constants.Lock.shared, 1000, None),
+    ],
+)
+def test_highlevel_lock_sets_vxi11_device_lock_flags_and_timeout(
+    lock_type, timeout, expected_flags
+):
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+    client.device_lock.return_value = 0
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        session = TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.no_lock,
+            1234,
+        )
+
+    library = highlevel.PyVisaLibrary()
+    library.sessions = {1: session}
+
+    if lock_type == constants.Lock.shared:
+        with pytest.raises(errors.VisaIOError):
+            library.lock(1, lock_type, timeout)
+        client.device_lock.assert_not_called()
+        return
+
+    key, status = library.lock(1, lock_type, timeout)
+
+    assert key == ""
+    assert status == constants.StatusCode.success
+    client.device_lock.assert_called_once_with(session.link, expected_flags, timeout)
+    

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -2,12 +2,23 @@
 
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
 from pyvisa import constants, rname
 
 from pyvisa_py.tcpip import TCPIPInstrVxi11
 
 
-def test_open_with_exclusive_lock_passes_lock_to_create_link():
+@pytest.mark.parametrize(
+    "open_timeout, expected_lock_timeout",
+    [
+        (0, 0),
+        (2500, 2500),
+        (constants.VI_TMO_INFINITE, 2**32 - 1),
+    ],
+)
+def test_open_with_exclusive_lock_passes_lock_to_create_link(
+    open_timeout, expected_lock_timeout
+):
     resource_name = "TCPIP::localhost::INSTR"
     parsed = rname.parse_resource_name(resource_name)
     client = MagicMock()
@@ -19,11 +30,11 @@ def test_open_with_exclusive_lock_passes_lock_to_create_link():
             resource_name,
             parsed,
             constants.AccessModes.exclusive_lock,
-            1234,
+            open_timeout,
         )
 
     client.create_link.assert_called_once_with(
-        ANY, 1, 1234, parsed.lan_device_name
+        ANY, 1, expected_lock_timeout, parsed.lan_device_name
     )
     
     

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -58,6 +58,43 @@ def test_open_without_exclusive_lock_passes_lock_to_create_link():
 
 
 @pytest.mark.parametrize(
+    "lock_timeout, expected_flags, expected_lock_timeout",
+    [
+        (0, 0x8, 0),
+        (1500, 0x9, 1500),
+    ],
+)
+def test_write_sets_device_write_flags_and_lock_timeout(
+    lock_timeout, expected_flags, expected_lock_timeout
+):
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+    client.device_write.return_value = (0, 3)
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        session = TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.no_lock,
+            1234,
+        )
+
+    session.lock_timeout = lock_timeout
+    status = session.write(b"abc")
+
+    assert status == (3, constants.StatusCode.success)
+    args, _ = client.device_write.call_args
+    assert args[0] == session.link
+    assert args[1] == session._io_timeout
+    assert args[2] == expected_lock_timeout
+    assert args[3] == expected_flags
+    assert args[4] == b"abc"
+
+
+@pytest.mark.parametrize(
     "lock_type, timeout, expected_flags",
     [
         (constants.Lock.exclusive, 0, 0x0),

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -17,7 +17,6 @@ from pyvisa_py.tcpip import TCPIPInstrVxi11
         (constants.VI_TMO_INFINITE, 2**32 - 1),
     ],
 )
-
 def test_open_with_exclusive_lock_passes_lock_to_create_link(
     open_timeout, expected_lock_timeout
 ):
@@ -38,8 +37,8 @@ def test_open_with_exclusive_lock_passes_lock_to_create_link(
     client.create_link.assert_called_once_with(
         ANY, 1, expected_lock_timeout, parsed.lan_device_name
     )
-    
-    
+
+
 def test_open_without_exclusive_lock_passes_lock_to_create_link():
     resource_name = "TCPIP::localhost::INSTR"
     parsed = rname.parse_resource_name(resource_name)
@@ -55,9 +54,7 @@ def test_open_without_exclusive_lock_passes_lock_to_create_link():
             1234,
         )
 
-    client.create_link.assert_called_once_with(
-        ANY, 0, 0, parsed.lan_device_name
-    )
+    client.create_link.assert_called_once_with(ANY, 0, 0, parsed.lan_device_name)
 
 
 @pytest.mark.parametrize(
@@ -101,4 +98,3 @@ def test_highlevel_lock_sets_vxi11_device_lock_flags_and_timeout(
     assert key == ""
     assert status == constants.StatusCode.success
     client.device_lock.assert_called_once_with(session.link, expected_flags, timeout)
-    

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -3,8 +3,8 @@
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from pyvisa import constants, errors, rname
 
+from pyvisa import constants, errors, rname
 from pyvisa_py import highlevel
 from pyvisa_py.tcpip import TCPIPInstrVxi11
 

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -58,15 +58,13 @@ def test_open_without_exclusive_lock_passes_lock_to_create_link():
 
 
 @pytest.mark.parametrize(
-    "lock_timeout, expected_flags, expected_lock_timeout",
+    "lockwait, expected_flags",
     [
-        (0, 0x8, 0),
-        (1500, 0x9, 1500),
+        (0, 0x8),
+        (1, 0x9),
     ],
 )
-def test_write_sets_device_write_flags_and_lock_timeout(
-    lock_timeout, expected_flags, expected_lock_timeout
-):
+def test_write_sets_device_write_flags_and_lock_timeout(lockwait, expected_flags):
     resource_name = "TCPIP::localhost::INSTR"
     parsed = rname.parse_resource_name(resource_name)
     client = MagicMock()
@@ -82,7 +80,11 @@ def test_write_sets_device_write_flags_and_lock_timeout(
             1234,
         )
 
-    session.lock_timeout = lock_timeout
+    session.attrs[constants.ResourceAttribute.lockwait] = lockwait
+    if lockwait:
+        expected_lock_timeout = session._io_timeout
+    else:
+        expected_lock_timeout = constants.VI_TMO_IMMEDIATE
     status = session.write(b"abc")
 
     assert status == (3, constants.StatusCode.success)

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -80,7 +80,7 @@ def test_write_sets_device_write_flags_and_lock_timeout(lockwait, expected_flags
             1234,
         )
 
-    session.attrs[constants.ResourceAttribute.lockwait] = lockwait
+    session.attrs[constants.ResourceAttribute.lockwait] = lockwait  # type: ignore[attr-defined]
     if lockwait:
         expected_lock_timeout = session._io_timeout
     else:

--- a/pyvisa_py/testsuite/test_open_timeout.py
+++ b/pyvisa_py/testsuite/test_open_timeout.py
@@ -8,7 +8,9 @@ caller supplies no ``open_timeout``. Every transport has to read that 0 as
 """
 
 import pytest
+from pyvisa import constants, errors
 
+from pyvisa_py import highlevel
 from pyvisa_py.common import DEFAULT_OPEN_TIMEOUT, connect_timeout
 from pyvisa_py.protocols import hislip, rpc
 
@@ -63,3 +65,57 @@ def test_hislip_connect_deadline(monkeypatch, open_timeout, expected):
         hislip.Instrument("localhost", open_timeout=open_timeout)
     # The deadline is set before connect() is attempted.
     assert seen == [expected]
+
+
+
+# Per per VPP-4.3 RECOMMENDATION 4.3.2, the access_mode argument to open()
+# may be interpreted as having no influence on the open timeout.
+# The code now passes the access_mode to the VXI-11 client, but it is not used in the timeout calculation.
+# It does have an influence on the lock timeout, but that is test in `test_locks.py`
+
+@pytest.mark.parametrize("access_mode", list(constants.AccessModes))
+@pytest.mark.parametrize(
+    "resource_name, transport",
+    [
+        ("TCPIP::localhost::hislip0,4880::INSTR", "hislip"),
+        ("TCPIP::localhost,1234::INSTR", "vxi11"),
+    ],
+)
+def test_highlevel_open_access_modes_preserve_open_timeout(
+    monkeypatch, access_mode, resource_name, transport
+):
+    """Every access mode preserves the open timeout through the high-level path."""
+    seen = []
+
+    class FakeSocket:
+        def settimeout(self, value):
+            seen.append(value)
+
+        def connect(self, address):
+            raise OSError("connection intentionally not established")
+
+        def setblocking(self, value):
+            pass
+
+        def connect_ex(self, address):
+            return 0
+
+        def close(self):
+            pass
+
+        def setsockopt(self, *args):
+            pass
+
+    def fake_connect(sock, host, port, timeout=0):
+        seen.append(timeout)
+        return False
+
+    monkeypatch.setattr(hislip.socket, "socket", lambda *args, **kwargs: FakeSocket())
+    monkeypatch.setattr(rpc, "_connect", fake_connect)
+
+    library = highlevel.PyVisaLibrary()
+    resource_manager, _ = library.open_default_resource_manager()
+    with pytest.raises(errors.VisaIOError):
+        library.open(resource_manager, resource_name, access_mode, 2500)
+
+    assert seen == [2.5]

--- a/pyvisa_py/testsuite/test_open_timeout.py
+++ b/pyvisa_py/testsuite/test_open_timeout.py
@@ -67,11 +67,11 @@ def test_hislip_connect_deadline(monkeypatch, open_timeout, expected):
     assert seen == [expected]
 
 
-
 # Per per VPP-4.3 RECOMMENDATION 4.3.2, the access_mode argument to open()
 # may be interpreted as having no influence on the open timeout.
 # The code now passes the access_mode to the VXI-11 client, but it is not used in the timeout calculation.
 # It does have an influence on the lock timeout, but that is test in `test_locks.py`
+
 
 @pytest.mark.parametrize("access_mode", list(constants.AccessModes))
 @pytest.mark.parametrize(

--- a/pyvisa_py/testsuite/test_open_timeout.py
+++ b/pyvisa_py/testsuite/test_open_timeout.py
@@ -8,8 +8,8 @@ caller supplies no ``open_timeout``. Every transport has to read that 0 as
 """
 
 import pytest
-from pyvisa import constants, errors
 
+from pyvisa import constants, errors
 from pyvisa_py import highlevel
 from pyvisa_py.common import DEFAULT_OPEN_TIMEOUT, connect_timeout
 from pyvisa_py.protocols import hislip, rpc

--- a/pyvisa_py/testsuite/test_remote_local.py
+++ b/pyvisa_py/testsuite/test_remote_local.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pyvisa import constants
+from pyvisa import constants, rname
 from pyvisa_py.tcpip import TCPIPInstrHiSLIP, TCPIPInstrVxi11
 
 
@@ -21,11 +21,22 @@ from pyvisa_py.tcpip import TCPIPInstrHiSLIP, TCPIPInstrVxi11
     ],
 )
 def test_vxi11_gpib_control_ren_calls_expected_device_method(mode, expected_method):
-    session = object.__new__(TCPIPInstrVxi11)
-    session.interface = MagicMock()
-    session.link = 7
-    session.lock_timeout = 1234
-    session._io_timeout = 5678
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+    client.device_write.return_value = (0, 3)
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        session = TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.no_lock,
+            1234,
+        )
+
+    session.attrs[constants.ResourceAttribute.lockwait] = 0  # type: ignore[attr-defined]
 
     session.interface.device_local.return_value = 0
     session.interface.device_remote.return_value = 0
@@ -33,7 +44,7 @@ def test_vxi11_gpib_control_ren_calls_expected_device_method(mode, expected_meth
     assert session.gpib_control_ren(mode) == constants.StatusCode.success
 
     getattr(session.interface, expected_method).assert_called_once_with(
-        session.link, 0, session.lock_timeout, session._io_timeout
+        session.link, 0, 0, session._io_timeout
     )
 
     if expected_method == "device_remote":
@@ -44,11 +55,22 @@ def test_vxi11_gpib_control_ren_calls_expected_device_method(mode, expected_meth
 
 @pytest.mark.parametrize("invalid_mode", [-1, 999, "bogus", None, object()])
 def test_vxi11_gpib_control_ren_rejects_unsupported_modes(invalid_mode):
-    session = object.__new__(TCPIPInstrVxi11)
-    session.interface = MagicMock()
-    session.link = 7
-    session.lock_timeout = 1234
-    session._io_timeout = 5678
+    resource_name = "TCPIP::localhost::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    client = MagicMock()
+    client.create_link.return_value = (0, 1, 0, 1024)
+    client.device_write.return_value = (0, 3)
+
+    with patch("pyvisa_py.tcpip.Vxi11CoreClient", return_value=client):
+        session = TCPIPInstrVxi11(
+            1,
+            resource_name,
+            parsed,
+            constants.AccessModes.no_lock,
+            1234,
+        )
+
+    session.attrs[constants.ResourceAttribute.lockwait] = 0  # type: ignore[attr-defined]
 
     assert session.gpib_control_ren(invalid_mode) == (
         constants.StatusCode.error_nonsupported_operation

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -27,6 +27,7 @@ class TestTCPIPInstrVxi11Read:
             ResourceAttribute.termchar_enabled: termchar_enabled,
             ResourceAttribute.termchar: ord("\n"),
             ResourceAttribute.suppress_end_enabled: suppress_end_enabled,
+            ResourceAttribute.lockwait: 0,
         }
         return sess
 

--- a/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
+++ b/pyvisa_py/testsuite/test_tcpip_vxi11_read.py
@@ -19,7 +19,6 @@ class TestTCPIPInstrVxi11Read:
         sess = object.__new__(TCPIPInstrVxi11)
         sess.interface = MagicMock()
         sess.link = 1
-        sess.lock_timeout = 10000
         sess.max_recv_size = 1024
         sess._io_timeout = 5000
         sess.timeout = 5
@@ -27,7 +26,7 @@ class TestTCPIPInstrVxi11Read:
             ResourceAttribute.termchar_enabled: termchar_enabled,
             ResourceAttribute.termchar: ord("\n"),
             ResourceAttribute.suppress_end_enabled: suppress_end_enabled,
-            ResourceAttribute.lockwait: 0,
+            ResourceAttribute.lockwait: 0,  # type: ignore[attr-defined]
         }
         return sess
 


### PR DESCRIPTION
**Why**

This allows more compliant lock handling on VXI-11.

- [x] Closes #583
- [x] Executed ``pre-commit`` with no errors 
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
