### PR TITLE
Check SO_ERROR before reporting a connection established

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,10 @@ PyVISA-py Changelog
   character detection, allowed use of suppress_end_en, corrected timeout handling.
   Closes #608 PR #612
 - Fixed crash on DEVICE_ENABLE_SRQ(off) and accept malformed SRQ packets. Closes #620 PR #621
+- Opening a VXI-11 resource whose instrument is unreachable now fails with a
+  VISA error rather than an OSError. A refused connection makes the socket
+  ready for select, which was taken for a completed connection, so the failure
+  only surfaced on the first send.
 - Set the TCP keepalive probe timers defensively for all TCPIP resources.
   ``VI_ATTR_TCPIP_KEEPALIVE`` raised ``AttributeError`` on platforms without
   ``socket.TCP_KEEPIDLE``, which includes macOS.

--- a/pyvisa_py/protocols/rpc.py
+++ b/pyvisa_py/protocols/rpc.py
@@ -19,6 +19,7 @@ Original source:
 """
 
 import enum
+import os
 import select
 import socket
 import struct
@@ -434,6 +435,17 @@ def _connect(sock, host, port, timeout=0):
         # use select to wait for socket ready, max `select_timout` seconds
         r, w, _x = select.select([sock], [sock], [], select_timout)
         if sock in r or sock in w:
+            # Readiness alone does not mean the connection was established. A
+            # refused connect also makes the socket ready, with the reason in
+            # SO_ERROR. Without this check the failure surfaces later, as an
+            # OSError from the first send, which is not a VISA error.
+            err = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+            if err != 0:
+                LOGGER.debug(
+                    "Connect to %s:%s failed: %s", host, port, os.strerror(err)
+                )
+                sock.close()
+                return False
             return True
 
         if time.time() >= finish_time:

--- a/pyvisa_py/testsuite/test_rpc.py
+++ b/pyvisa_py/testsuite/test_rpc.py
@@ -1,0 +1,62 @@
+"""Tests for the ONC RPC layer used by VXI-11.
+
+:copyright: 2014-2024 by PyVISA-py Authors, see AUTHORS for more details.
+:license: MIT, see LICENSE for more details.
+
+"""
+
+import socket
+
+import pytest
+
+from pyvisa_py.protocols import rpc
+
+
+@pytest.fixture
+def closed_port():
+    """A port on the loopback interface with nothing listening on it."""
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+@pytest.fixture
+def listening_port():
+    """A port that accepts connections. Yields (port, server socket)."""
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    yield server.getsockname()[1], server
+    server.close()
+
+
+def test_connect_reports_failure_for_a_refused_port(closed_port):
+    """A refused connection must not be reported as a connected socket.
+
+    connect_ex is non-blocking here, so the result arrives through select.
+    A refused connection makes the socket ready with SO_ERROR set, which used
+    to be taken for success. The first send then raised BrokenPipeError, and
+    that left the VISA call as an OSError rather than a VISA status.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        assert rpc._connect(sock, "127.0.0.1", closed_port, 2.0) is False
+    finally:
+        sock.close()
+
+
+def test_connect_reports_success_for_a_listening_port(listening_port):
+    port, _server = listening_port
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        assert rpc._connect(sock, "127.0.0.1", port, 2.0) is True
+    finally:
+        sock.close()
+
+
+def test_client_raises_rpcerror_for_a_refused_port(closed_port):
+    """RawTCPClient turns a failed connect into RPCError, which callers map."""
+    with pytest.raises(rpc.RPCError):
+        rpc.RawTCPClient("127.0.0.1", 0x0607AF, 1, closed_port, open_timeout=2000)


### PR DESCRIPTION
_connect drives a non-blocking connect and waits for the result with select. It assumed that once the socket was ready it was connected. But a refused connection also makes the socket ready, with the reason in SO_ERROR, and the connection would just fail on the first send. viOpen raised an OSError (BrokenPipeError on macOS, ConnectionRefusedError on Linux), rather than a VisaIOError, which complicates error handling.

```python
import pyvisa

# Nothing is listening on port 9999. The ",9999" names the VXI-11 core channel
# port directly, so this does not depend on a portmapper being reachable.
try:
    pyvisa.ResourceManager("@py").open_resource(
        "TCPIP::127.0.0.1,9999::inst0::INSTR", open_timeout=2000
    )
except pyvisa.errors.VisaIOError as exc:
    print("VisaIOError:", exc.abbreviation)
except Exception as exc:
    print("not a VISA error:", type(exc).__name__, exc)
```

Before, on macOS 24.6.0 / Python 3.14.7:

```
not a VISA error: BrokenPipeError [Errno 32] Broken pipe
```

and on Linux 6.12.13 / Python 3.13.15:

```
not a VISA error: ConnectionRefusedError [Errno 111] Connection refused
```

After, on both:

```
VisaIOError: VI_ERROR_RSRC_NFOUND
```

The original errno from the socket failure is sent to the debug logger.

<!--

Thanks for wanting to contribute to PyVISA-py :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   the pre-commit hooks. Run ``pip install pre-commit && pre-commit install``
   and they will run automatically; run ``pre-commit`` alone to test without
   committing.

3. Please ensure that you have written units tests for the changes made/features
   added if possible. If it is not possible please be sure to provide sufficient
   details inline justifying the change, as it can sometimes be hard to track
   changes made to support a particular behavior in an instrument.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``pre-commit`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate -> does this need documentation?
- [x] Added an entry to the CHANGES file
