### PR TITLE
Lock on hislip

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
-- hislip: allow service request events. Closes #625 PR #626
+- HiSLIP: allow locking. Closes #635 PR #643
+- HiSLIP: allow service request events. Closes #625 PR #626
 - VXI-11 (TCPIP::INSTR):
   Locking compliance improvement. Exclusive locking works now,
   Removed `session.lock_timeout`, no longer needed for instruments

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA-py Changelog
 0.9.0 (unreleased)
 ------------------
 
+- hislip: allow service request events. Closes #625 PR #626
 - VXI-11: Allow link ID 0 to be used for SRQ in agreement with the specs
   and other implementations. Closes #618 PR #619
 - Removed return packet on device_intr_srq. Closes #614 PR #615

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -273,11 +273,14 @@ Event handling is not affected by locking.
     - the length of the timeouts (timeouts may be significantly longer or shorter than specified)
     - the sequencing: some devices, once already locked, will allow `open_resource`
       to succeed (as they should per VXI-11 spec RULE B.6.6), but others don't.
+    
+    Worse, some instruments do not clean up locks after the connection is closed. 
+    That is not only a violation of the expected behavior according to the standards, 
+    but can also lead to unexpected locking issues in subsequent connections, requiring an instrument reboot.
 
-    Keysight VISA and PyVISA-py both support the lock timeout attribute ``VI_KTATTR_LOCKWAIT``.
-
-    NI-VISA and R&S VISA have no known means of controlling the lock timeout, and mostly 
-    use the I/O timeout and/or internal timing for lock timeout handling.
+    About the lock timeout handling: Keysight VISA and PyVISA-py both support the lock timeout 
+    attribute ``VI_KTATTR_LOCKWAIT``. NI-VISA and R&S VISA have no known means of controlling 
+    the lock timeout, and mostly use the I/O timeout and/or internal timing for lock timeout handling.
 
     If you are debugging locking issues, note that NI-VISA supports
     the lock-on-open method, but underneath uses the lock-after-open method, and, 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -173,10 +173,9 @@ omit the argument.
 Locking
 -------
 
-**PyVISA-Py only supports exclusive locking, and only on VXI-11. Shared locks and nested locking are not supported.** 
+**PyVISA-Py only supports exclusive locking on VXI-11 and HiSLIP. Shared locks and nested locking are not supported.** 
 
-Socket instruments (``TCPIP::SOCKET``) do not support locking.
-HiSLIP instruments (``TCPIP::hislip``) could support locking, but PyVISA-Py does not yet implement this feature.
+Serial and TCPIP::SOCKET instruments do not support locking.
 
 With exclusive locking, only one session can be used at a time on an instrument.  
 If another session has a lock, another client will not be able to communicate with
@@ -219,7 +218,7 @@ If you have not locked the instrument, and want to control the behaviour of your
 in case another program or session has locked it, you must choose one of the following methods:
 
 - Request a lock via ``inst.lock_excl()``. This is the most portable. See above.
-- Configure the lock timeout via the Keysight and PyVISA-Py specific attribute ``VI_KTATTR_LOCKWAIT`` (0x0FFF002B)
+- Only for VXI-11: Configure the lock timeout via the Keysight and PyVISA-Py specific attribute ``VI_KTATTR_LOCKWAIT`` (0x0FFF002B)
 
     When using ``VI_KTATTR_LOCKWAIT`` on an instrument that is locked by another session:
 
@@ -250,10 +249,14 @@ in case another program or session has locked it, you must choose one of the fol
     >>> # Do your operations
 
 
-Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``VI_KTATTR_LOCKWAIT``.
+    Note that ``open_resource()`` and ``lock_excl()`` use their own timeout values, and do not use ``VI_KTATTR_LOCKWAIT``.
 
-``session.lock_timeout``, from previous PyVISA-Py versions, has been removed, and replaced by the 
-use of ``VI_KTATTR_LOCKWAIT``, as it is easier, more predictable and more portable.
+    ``session.lock_timeout``, from previous PyVISA-Py versions, has been removed, and replaced by the 
+    use of ``VI_KTATTR_LOCKWAIT``, as it is easier, more predictable and more portable.
+
+The ``VI_ATTR_RSRC_LOCK_STATE`` attribute is fully supported on HiSLIP: it reflects the current lock state of the resource accurately.
+On VXI-11, it represents the lock state of the session, so it may not accurately reflect the lock state of the underlying resource itself.
+
 
 Event handling is not affected by locking. 
 

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -1066,7 +1066,7 @@ class Instrument:
         )
         return response.control_code
 
-    def async_lock_request(self, timeout: float, lock_string: str = "") -> str:
+    def async_lock_request(self, timeout_ms: int, lock_string: str = "") -> str:
         """
         perform an AsyncLock request transaction.
         returns the lock_response from the AsyncLockResponse packet.
@@ -1075,7 +1075,6 @@ class Instrument:
         #     C->S: AsyncLock
         #     S->C: AsyncLockResponse
         ctrl_code = LOCKCONTROLCODE["request"]
-        timeout_ms = int(1e3 * timeout)
         response = self._async_channel.request(
             "AsyncLock",
             ctrl_code,

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -574,12 +574,14 @@ class AsyncChannel:
                 continue
             except OSError:
                 break
-            except Exception:
-                LOGGER.exception("Async channel reader stopped due to protocol error")
+            except Exception as e:
+                if not self._stop.is_set():
+                    LOGGER.exception(f"Async channel reader stopped due to protocol error: {e}")
                 with self._state_lock:
                     pending = self._pending_request
                     if pending is not None and not pending["done"]:
-                        pending["error"] = RuntimeError("async channel protocol error")
+                        if not self._stop.is_set():
+                            pending["error"] = RuntimeError("async channel protocol error")
                         pending["done"] = True
                         self._pending_request = None
                         self._state_lock.notify_all()

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -520,8 +520,8 @@ class AsyncChannel:
 
     def _read_message(self) -> AsyncMessage:
         header = self._read_exact(HEADER_SIZE)
-        prologue, msg_type, control_code, message_parameter, payload_length = struct.unpack(
-            HEADER_FORMAT, header
+        prologue, msg_type, control_code, message_parameter, payload_length = (
+            struct.unpack(HEADER_FORMAT, header)
         )
 
         if prologue != b"HS":
@@ -539,7 +539,10 @@ class AsyncChannel:
         )
 
     def _deliver_event(self, message: AsyncMessage) -> None:
-        if message.msg_type == "AsyncServiceRequest" and self._event_callback is not None:
+        if (
+            message.msg_type == "AsyncServiceRequest"
+            and self._event_callback is not None
+        ):
             try:
                 self._event_callback(message.control_code)
             except Exception:
@@ -576,12 +579,16 @@ class AsyncChannel:
                 break
             except Exception as e:
                 if not self._stop.is_set():
-                    LOGGER.exception(f"Async channel reader stopped due to protocol error: {e}")
+                    LOGGER.exception(
+                        f"Async channel reader stopped due to protocol error: {e}"
+                    )
                 with self._state_lock:
                     pending = self._pending_request
                     if pending is not None and not pending["done"]:
                         if not self._stop.is_set():
-                            pending["error"] = RuntimeError("async channel protocol error")
+                            pending["error"] = RuntimeError(
+                                "async channel protocol error"
+                            )
                         pending["done"] = True
                         self._pending_request = None
                         self._state_lock.notify_all()
@@ -591,7 +598,9 @@ class AsyncChannel:
                 with self._state_lock:
                     pending = self._pending_request
                     if pending is not None and not pending["done"]:
-                        pending["error"] = HiSLIPInterruptedError(message.message_parameter)
+                        pending["error"] = HiSLIPInterruptedError(
+                            message.message_parameter
+                        )
                         pending["done"] = True
                         self._pending_request = None
                         self._state_lock.notify_all()

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -1071,6 +1071,8 @@ class Instrument:
             0,
             expected_response="AsyncLockInfoResponse",
         )
+        # TODO if you want to support shared locks, you may need to 
+        # interpret `clients_holding_locks `
         return response.control_code
 
     def async_lock_request(self, timeout_ms: int, lock_string: str = "") -> str:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -344,10 +344,10 @@ class AsyncInitializeResponse(RxHeader):
         message_param = struct.unpack("!4x2s2s8x", self.header)
         self.server_capabilities = message_param[0]
         self.vendor_id = message_param[1]
-        # Server capabilities: 
+        # Server capabilities:
         # "If bit 0 is set the secure connection capability is supported."
         # but we do not support secure connection (yet). So this is unused for now.
-        
+
 
 class AsyncMaxMsgSizeResponse(RxHeader):
     def __init__(self, sock: socket.socket) -> None:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -9,9 +9,10 @@ import socket
 import struct
 import threading
 import time
-from typing import Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
 
-from pyvisa_py.common import BytesBuffer, MutableBytesBuffer
+from pyvisa_py.common import BytesBuffer, LOGGER, MutableBytesBuffer
 
 PORT = 4880
 
@@ -338,7 +339,7 @@ class AsyncInitializeResponse(RxHeader):
         super().__init__(sock, "AsyncInitializeResponse")
         assert self.control_code == 0
         assert self.payload_length == 0
-        self.vendor_id = struct.unpack("!4x4s8x", self.header)
+        self.vendor_id = struct.unpack("!4x4s8x", self.header)[0]
 
 
 class AsyncMaxMsgSizeResponse(RxHeader):
@@ -393,7 +394,6 @@ class AsyncRemoteLocalResponse(RxHeader):
 
 class AsyncServiceRequest(RxHeader):
     def __init__(self, sock: socket.socket) -> None:
-        print("AsyncServiceRequest received")
         super().__init__(sock, "AsyncServiceRequest")
         self.server_status = self.control_code
         assert self.message_parameter == 0
@@ -406,6 +406,204 @@ class AsyncStatusResponse(RxHeader):
         self.server_status = self.control_code
         assert self.message_parameter == 0
         assert self.payload_length == 0
+
+
+@dataclass
+class AsyncMessage:
+    msg_type: str
+    control_code: int
+    message_parameter: int
+    payload: bytes
+
+
+class AsyncChannel:
+    """Own the async HiSLIP socket and dispatch unsolicited messages."""
+
+    def __init__(
+        self,
+        sock: socket.socket,
+        event_callback: Optional[Callable[[int], None]] = None,
+        interrupt_callback: Optional[Callable[[int], None]] = None,
+    ) -> None:
+        self._sock = sock
+        self._event_callback = event_callback
+        self._interrupt_callback = interrupt_callback
+        self._send_lock = threading.Lock()
+        self._state_lock = threading.Condition()
+        self._pending_request: Optional[dict] = None
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        try:
+            self._sock.shutdown(socket.SHUT_RDWR)
+        except Exception:
+            pass
+        if self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        try:
+            self._sock.close()
+        except Exception:
+            pass
+
+    def request(
+        self,
+        msg_type: str,
+        control_code: int,
+        message_parameter: int,
+        payload: bytes = b"",
+        expected_response: Optional[str] = None,
+    ) -> AsyncMessage:
+        if expected_response is None:
+            raise ValueError("expected_response is required for async requests")
+
+        timeout = self._sock.gettimeout()
+        with self._state_lock:
+            if self._pending_request is not None:
+                raise RuntimeError("another async request is already pending")
+            pending = {
+                "expected_response": expected_response,
+                "response": None,
+                "error": None,
+                "done": False,
+            }
+            self._pending_request = pending
+
+        try:
+            with self._send_lock:
+                send_msg(self._sock, msg_type, control_code, message_parameter, payload)
+
+            deadline = None if timeout is None else time.monotonic() + float(timeout)
+            with self._state_lock:
+                while not pending["done"] and pending["error"] is None:
+                    if deadline is None:
+                        self._state_lock.wait()
+                    else:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        self._state_lock.wait(remaining)
+
+                if not pending["done"]:
+                    if self._pending_request is pending:
+                        self._pending_request = None
+                    raise socket.timeout("timed out")
+
+                if pending["error"] is not None:
+                    raise pending["error"]
+                response = pending["response"]
+                assert response is not None
+                return response
+        finally:
+            with self._state_lock:
+                if self._pending_request is pending and not pending["done"]:
+                    self._pending_request = None
+
+    def _read_exact(self, size: int) -> bytes:
+        data = bytearray()
+        while len(data) < size:
+            if self._stop.is_set():
+                raise OSError("async channel stopped")
+            readable, _, _ = select.select([self._sock], [], [], 0.5)
+            if not readable:
+                continue
+            chunk = self._sock.recv(size - len(data))
+            if not chunk:
+                raise RuntimeError("async channel closed")
+            data.extend(chunk)
+        return bytes(data)
+
+    def _read_message(self) -> AsyncMessage:
+        header = self._read_exact(HEADER_SIZE)
+        prologue, msg_type, control_code, message_parameter, payload_length = struct.unpack(
+            HEADER_FORMAT, header
+        )
+
+        if prologue != b"HS":
+            raise RuntimeError("protocol synchronization error on async channel")
+
+        if msg_type not in MESSAGETYPE_STR:
+            raise RuntimeError("unrecognized async message type: %d" % msg_type)
+
+        payload = self._read_exact(payload_length) if payload_length else b""
+        return AsyncMessage(
+            msg_type=MESSAGETYPE_STR[msg_type],
+            control_code=control_code,
+            message_parameter=message_parameter,
+            payload=payload,
+        )
+
+    def _deliver_event(self, message: AsyncMessage) -> None:
+        if message.msg_type == "AsyncServiceRequest" and self._event_callback is not None:
+            try:
+                self._event_callback(message.control_code)
+            except Exception:
+                LOGGER.exception("Error handling async service request")
+
+    def _deliver_interrupt(self, message: AsyncMessage) -> None:
+        if self._interrupt_callback is None:
+            return
+        try:
+            self._interrupt_callback(message.message_parameter)
+        except Exception:
+            LOGGER.exception("Error handling async interruption")
+
+    def _complete_pending(self, message: AsyncMessage) -> bool:
+        with self._state_lock:
+            pending = self._pending_request
+            if pending is None or pending["done"]:
+                return False
+            if message.msg_type != pending["expected_response"]:
+                return False
+            pending["response"] = message
+            pending["done"] = True
+            self._pending_request = None
+            self._state_lock.notify_all()
+            return True
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                message = self._read_message()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            except Exception:
+                LOGGER.exception("Async channel reader stopped due to protocol error")
+                with self._state_lock:
+                    pending = self._pending_request
+                    if pending is not None and not pending["done"]:
+                        pending["error"] = RuntimeError("async channel protocol error")
+                        pending["done"] = True
+                        self._pending_request = None
+                        self._state_lock.notify_all()
+                break
+
+            if message.msg_type == "AsyncInterrupted":
+                with self._state_lock:
+                    pending = self._pending_request
+                    if pending is not None and not pending["done"]:
+                        pending["error"] = HiSLIPInterruptedError(message.message_parameter)
+                        pending["done"] = True
+                        self._pending_request = None
+                        self._state_lock.notify_all()
+                self._deliver_interrupt(message)
+                continue
+
+            if self._complete_pending(message):
+                continue
+
+            if message.msg_type in {"AsyncServiceRequest"}:
+                self._deliver_event(message)
+                continue
+
+            LOGGER.debug("Ignoring unsolicited async message %s", message.msg_type)
 
 
 class DeviceClearAcknowledge(RxHeader):
@@ -453,6 +651,8 @@ class Instrument:
         timeout: Optional[float] = None,
         port: int = PORT,
         sub_address: str = "hislip0",
+        event_callback: Optional[Callable[[int], None]] = None,
+        interrupt_callback: Optional[Callable[[int], None]] = None,
     ) -> None:
         # init transaction:
         #     C->S: Initialize
@@ -490,10 +690,13 @@ class Instrument:
         self._async_init = self.async_initialize(session_id=init.session_id)
         # We set the user timeout once we managed to initialize the connection.
         self._async.settimeout(timeout)
-        
-        # TODO: the async channel, as now, is in reality still a sync connection. I send, and expect a reply.
-        # It is not built to receive async messages from the instrument, like AsyncServiceRequest. 
-        # I need to implement a thread that will listen to the async channel and dispatch messages to the right handler.
+
+        self._async_channel = AsyncChannel(
+            self._async,
+            event_callback=event_callback,
+            interrupt_callback=interrupt_callback,
+        )
+        self._async_channel.start()
 
         # initialize variables
         self.max_msg_size = DEFAULT_MAX_MSG_SIZE
@@ -511,8 +714,8 @@ class Instrument:
     # ================ #
 
     def close(self) -> None:
+        self._async_channel.close()
         self._sync.close()
-        self._async.close()
 
     @property
     def timeout(self) -> float:
@@ -821,9 +1024,15 @@ class Instrument:
         #     C->S: AsyncMaxMsgSize
         #     S->C: AsyncMaxMsgSizeResponse
         payload = struct.pack("!Q", size)
-        send_msg(self._async, "AsyncMaxMsgSize", 0, 0, payload)
-        response = AsyncMaxMsgSizeResponse(self._async)
-        return response.max_msg_size
+        response = self._async_channel.request(
+            "AsyncMaxMsgSize",
+            0,
+            0,
+            payload,
+            expected_response="AsyncMaxMsgSizeResponse",
+        )
+        assert len(response.payload) == 8
+        return struct.unpack("!Q", response.payload)[0]
 
     def async_lock_info(self) -> int:
         """
@@ -833,9 +1042,13 @@ class Instrument:
         # async_lock_info transaction:
         #     C->S: AsyncLockInfo
         #     S->C: AsyncLockInfoResponse
-        send_msg(self._async, "AsyncLockInfo", 0, 0)
-        response = AsyncLockInfoResponse(self._async)
-        return response.exclusive_lock
+        response = self._async_channel.request(
+            "AsyncLockInfo",
+            0,
+            0,
+            expected_response="AsyncLockInfoResponse",
+        )
+        return response.control_code
 
     def async_lock_request(self, timeout: float, lock_string: str = "") -> str:
         """
@@ -847,9 +1060,14 @@ class Instrument:
         #     S->C: AsyncLockResponse
         ctrl_code = LOCKCONTROLCODE["request"]
         timeout_ms = int(1e3 * timeout)
-        send_msg(self._async, "AsyncLock", ctrl_code, timeout_ms, lock_string.encode())
-        response = AsyncLockResponse(self._async)
-        return response.lock_response
+        response = self._async_channel.request(
+            "AsyncLock",
+            ctrl_code,
+            timeout_ms,
+            lock_string.encode(),
+            expected_response="AsyncLockResponse",
+        )
+        return LOCKRESPONSE[response.control_code]
 
     def async_lock_release(self) -> str:
         """
@@ -860,9 +1078,13 @@ class Instrument:
         #     C->S: AsyncLock
         #     S->C: AsyncLockResponse
         ctrl_code = LOCKCONTROLCODE["release"]
-        send_msg(self._async, "AsyncLock", ctrl_code, self.last_message_id)
-        response = AsyncLockResponse(self._async)
-        return response.lock_response
+        response = self._async_channel.request(
+            "AsyncLock",
+            ctrl_code,
+            self.last_message_id or 0,
+            expected_response="AsyncLockResponse",
+        )
+        return LOCKRESPONSE[response.control_code]
 
     def async_remote_local_control(self, remotelocalcontrol: str) -> None:
         """
@@ -872,10 +1094,12 @@ class Instrument:
         #     C->S: AsyncRemoteLocalControl
         #     S->C: AsyncRemoteLocalResponse
         ctrl_code = REMOTELOCALCONTROLCODE[remotelocalcontrol]
-        send_msg(
-            self._async, "AsyncRemoteLocalControl", ctrl_code, self.last_message_id
+        self._async_channel.request(
+            "AsyncRemoteLocalControl",
+            ctrl_code,
+            self.last_message_id or 0,
+            expected_response="AsyncRemoteLocalResponse",
         )
-        AsyncRemoteLocalResponse(self._async)
 
     def async_status_query(self) -> int:
         """
@@ -885,19 +1109,27 @@ class Instrument:
         # async_status_query transaction:
         #     C->S: AsyncStatusQuery
         #     S->C: AsyncStatusResponse
-        send_msg(self._async, "AsyncStatusQuery", self._rmt, self._message_id)
+        response = self._async_channel.request(
+            "AsyncStatusQuery",
+            self._rmt,
+            self._message_id,
+            expected_response="AsyncStatusResponse",
+        )
         self._rmt = 0
-        response = AsyncStatusResponse(self._async)
-        return response.server_status
+        return response.control_code
 
     def async_device_clear(self) -> int:
         """
         perform an AsyncDeviceClear transaction.
         returns the feature_bitmap from the AsyncDeviceClearAcknowledge packet.
         """
-        send_msg(self._async, "AsyncDeviceClear", 0, 0)
-        response = AsyncDeviceClearAcknowledge(self._async)
-        return response.feature_bitmap
+        response = self._async_channel.request(
+            "AsyncDeviceClear",
+            0,
+            0,
+            expected_response="AsyncDeviceClearAcknowledge",
+        )
+        return response.control_code
 
     def device_clear_complete(self, feature_bitmap: int) -> int:
         """

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -339,8 +339,15 @@ class AsyncInitializeResponse(RxHeader):
         super().__init__(sock, "AsyncInitializeResponse")
         assert self.control_code == 0
         assert self.payload_length == 0
-        self.vendor_id = struct.unpack("!4x4s8x", self.header)[0]
-
+        # Read the Message Parameter, it starts 4 bytes into the header and is 4 bytes long.
+        # Followed by 8 bytes of padding, since payload_length == 0
+        message_param = struct.unpack("!4x2s2s8x", self.header)
+        self.server_capabilities = message_param[0]
+        self.vendor_id = message_param[1]
+        # Server capabilities: 
+        # "If bit 0 is set the secure connection capability is supported."
+        # but we do not support secure connection (yet). So this is unused for now.
+        
 
 class AsyncMaxMsgSizeResponse(RxHeader):
     def __init__(self, sock: socket.socket) -> None:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -495,9 +495,14 @@ class AsyncChannel:
                     raise socket.timeout("timed out")
 
                 if pending["error"] is not None:
-                    raise pending["error"]
+                    if isinstance(pending["error"], Exception):
+                        raise pending["error"]
+                    else:
+                        raise RuntimeError(pending["error"])
                 response = pending["response"]
                 assert response is not None
+                if not isinstance(response, AsyncMessage):
+                    raise RuntimeError("unexpected response type: %s" % type(response))
                 return response
         finally:
             with self._state_lock:

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -393,6 +393,7 @@ class AsyncRemoteLocalResponse(RxHeader):
 
 class AsyncServiceRequest(RxHeader):
     def __init__(self, sock: socket.socket) -> None:
+        print("AsyncServiceRequest received")
         super().__init__(sock, "AsyncServiceRequest")
         self.server_status = self.control_code
         assert self.message_parameter == 0
@@ -489,6 +490,10 @@ class Instrument:
         self._async_init = self.async_initialize(session_id=init.session_id)
         # We set the user timeout once we managed to initialize the connection.
         self._async.settimeout(timeout)
+        
+        # TODO: the async channel, as now, is in reality still a sync connection. I send, and expect a reply.
+        # It is not built to receive async messages from the instrument, like AsyncServiceRequest. 
+        # I need to implement a thread that will listen to the async channel and dispatch messages to the right handler.
 
         # initialize variables
         self.max_msg_size = DEFAULT_MAX_MSG_SIZE

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -1071,7 +1071,7 @@ class Instrument:
             0,
             expected_response="AsyncLockInfoResponse",
         )
-        # TODO if you want to support shared locks, you may need to 
+        # TODO if you want to support shared locks, you may need to
         # interpret `clients_holding_locks `
         return response.control_code
 

--- a/pyvisa_py/protocols/hislip.py
+++ b/pyvisa_py/protocols/hislip.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Tuple
 
-from pyvisa_py.common import BytesBuffer, LOGGER, MutableBytesBuffer
+from pyvisa_py.common import LOGGER, BytesBuffer, MutableBytesBuffer, connect_timeout
 
 PORT = 4880
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -260,6 +260,7 @@ class TCPIPInstrHiSLIP(Session):
             lock_timeout = calculate_lock_timeout_from_open_timeout(self.open_timeout)
             _k, rv = self.lock(constants.Lock.exclusive, lock_timeout, "")
             if rv != StatusCode.success:
+                self.close()  # the operation was open_with_lock. If the lock fails, the open should also be reversed.
                 raise RuntimeError("Failed to acquire exclusive lock")
 
     def _handle_async_service_request(self, status_byte: int) -> None:

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -114,7 +114,7 @@ class TCPIPInstrHiSLIP(Session):
     session_type = (constants.InterfaceType.tcpip, "INSTR")
 
     _supported_event_types = {constants.EventType.service_request}
-    
+
     REMOTELOCALOPCODE: Final[dict[constants.RENLineOperation, str]] = {
         constants.RENLineOperation.address_gtl: "justGTL",
         constants.RENLineOperation.asrt: "enableRemote",

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -136,6 +136,13 @@ class TCPIPInstrHiSLIP(Session):
         constants.RENLineOperation.deassert: "disableRemote",
         constants.RENLineOperation.deassert_gtl: "disableAndGTL",
     }
+    
+    LOCKRESPONSE_TO_STATUSCODE: Final[dict[str, constants.StatusCode]] = {
+        hislip.LOCKRESPONSE[0]: constants.StatusCode.error_resource_locked,
+        hislip.LOCKRESPONSE[1]: constants.StatusCode.success,
+        hislip.LOCKRESPONSE[2]: constants.StatusCode.success,
+        hislip.LOCKRESPONSE[3]: constants.StatusCode.error_nonsupported_operation,
+    }
 
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource
@@ -193,7 +200,7 @@ class TCPIPInstrHiSLIP(Session):
                 f"on port {port} with lan device name {sub_address}"
             )
             raise OpenError() from e
-
+        
         # initialize the constant attributes
         self.attrs[ResourceAttribute.dma_allow_enabled] = constants.VI_FALSE
         self.attrs[ResourceAttribute.file_append_enabled] = constants.VI_FALSE
@@ -229,6 +236,18 @@ class TCPIPInstrHiSLIP(Session):
             self.get_keepalive,
             self.set_keepalive,
         )
+        
+        # and now handle the lock
+        if self.access_mode & constants.AccessModes.exclusive_lock:
+            # It wouldn't be too hard to implement shared locking, since
+            # the interface likely supports it, but for now we only handle exclusive locks.
+            
+            # about the timeout: Found nothing in the spec that says how to handle this.
+            if self.timeout is None:
+                self.timeout = 10.0  # default timeout in seconds
+            k, rv = self.lock(constants.Lock.exclusive, int(1e3 * self.timeout), "")
+            if rv != StatusCode.success:
+                raise RuntimeError("Failed to acquire exclusive lock")
 
     def _handle_async_service_request(self, status_byte: int) -> None:
         ctx = EventContext(
@@ -415,6 +434,67 @@ class TCPIPInstrHiSLIP(Session):
         errorcode = StatusCode.success
 
         return stb, errorcode
+    
+    def lock(
+        self,
+        lock_type: constants.Lock,
+        timeout: int,
+        requested_key: Optional[str] = None,
+    ) -> Tuple[str, constants.StatusCode]:
+        """Establishes an access mode to the specified resources.
+
+        Corresponds to viLock function of the VISA library.
+
+        Parameters
+        ----------
+        session : VISASession
+            Unique logical identifier to a session.
+        lock_type : constants.Lock
+            Specifies the type of lock requested.
+        timeout : int
+            Absolute time period (in milliseconds) that a resource waits to get
+            unlocked by the locking session before returning an error.
+        requested_key : Optional[str], optional
+            Requested locking key in the case of a shared lock. For an exclusive
+            lock it should be None.
+
+        Returns
+        -------
+        Optional[str]
+            Key that can then be passed to other sessions to share the lock, or
+            None for an exclusive lock.
+        StatusCode
+            Return value of the library call.
+
+        """
+        # For now, we only handle exclusive locks.
+        # It could be possible to handle shared locks in the future
+        if lock_type != constants.Lock.exclusive:
+            return "", StatusCode.error_nonsupported_operation
+
+        # requested_key is ignored for exclusive locks.
+        # Note to future: requested_key None is invalid: make it an empty string
+        rv = self.interface.async_lock_request(timeout, "")
+        # rv is from LOCKRESPONSE
+        
+        # TODO: look how to maintain self.attrs[ResourceAttribute.resource_lock_state]
+        return "", self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
+
+    def unlock(self) -> constants.StatusCode:
+        """Relinquish a lock for the specified resource.
+
+        Corresponds to viUnlock function of the VISA library.
+
+        Returns
+        -------
+        StatusCode
+            Return value of the library call.
+
+        """
+        rv = self.interface.async_lock_release("")
+        # rv is from LOCKRESPONSE
+        # TODO: look how to maintain self.attrs[ResourceAttribute.resource_lock_state]        
+        return self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
 
     def terminate(self, job_id: VISAJobID | None = None) -> StatusCode:
         """Cancel a pending I/O operation on this session.

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -569,8 +569,8 @@ class TCPIPInstrHiSLIP(Session):
         # for VI_ATTR_RSRC_LOCK_STATE.
         if attribute == constants.VI_ATTR_RSRC_LOCK_STATE:
             exclusive_lock = self.interface.async_lock_info()
-            # exclusive_lock: 0 – No exclusive lock granted
-            #                 1 – Exclusive lock granted
+            # exclusive_lock: 0: No exclusive lock granted
+            #                 1: Exclusive lock granted
             # we do not do shared locks (yet)
             if exclusive_lock not in (0, 1):
                 raise ValueError(f"Unexpected exclusive_lock value: {exclusive_lock}")

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -111,6 +111,8 @@ class TCPIPInstrHiSLIP(Session):
     # want it to be registered in the _session_classes array, but we still
     # need to define session_type to make the set_attribute machinery work.
     session_type = (constants.InterfaceType.tcpip, "INSTR")
+    
+    _supported_event_types = {constants.EventType.service_request}
 
     # Override parsed to take into account the fact that this class is only used
     # for a specific kind of resource

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -165,7 +165,7 @@ class TCPIPInstrHiSLIP(Session):
     def after_parsing(self) -> None:
         # TODO: board_number not handled
 
-        parsed = cast(rname.TCPIPInstr, self.parsed)
+        parsed = self.parsed
 
         if "," in parsed.lan_device_name:
             sub_address, port_str = parsed.lan_device_name.split(",")

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -258,7 +258,7 @@ class TCPIPInstrHiSLIP(Session):
             # about the timeout: Found nothing in the spec that says how to handle this.
             # Do what is done by VXI-11
             lock_timeout = calculate_lock_timeout_from_open_timeout(self.open_timeout)
-            k, rv = self.lock(constants.Lock.exclusive, lock_timeout, "")
+            _k, rv = self.lock(constants.Lock.exclusive, lock_timeout, "")
             if rv != StatusCode.success:
                 raise RuntimeError("Failed to acquire exclusive lock")
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -146,7 +146,7 @@ class TCPIPInstrHiSLIP(Session):
             port = 4880
 
         try:
-            self._async_interrupted_message_id = None
+            self._async_interrupted_message_id: Optional[int] = None
             self.interface = hislip.Instrument(
                 parsed.host_address,
                 # ``open_timeout`` is already in milliseconds, which is what

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -79,13 +79,9 @@ def calculate_lock_timeout_from_open_timeout(open_timeout: Optional[int]) -> int
     # lock_timeout can be 0 for immediate
     lock_timeout = open_timeout
     if lock_timeout is None:
-        lock_timeout = (
-            10000  # default lock timeout in ms. This shouldn't happen
-        )
+        lock_timeout = 10000  # default lock timeout in ms. This shouldn't happen
     if lock_timeout == constants.VI_TMO_INFINITE:
-        lock_timeout = (
-            2**32 - 1
-        )  # This is dangerous, but hey, the caller wanted it.
+        lock_timeout = 2**32 - 1  # This is dangerous, but hey, the caller wanted it.
     if lock_timeout == constants.VI_TMO_IMMEDIATE:
         lock_timeout = 0  # This is NOP, but makes the code more readable
     return lock_timeout
@@ -152,7 +148,7 @@ class TCPIPInstrHiSLIP(Session):
         constants.RENLineOperation.deassert: "disableRemote",
         constants.RENLineOperation.deassert_gtl: "disableAndGTL",
     }
-    
+
     LOCKRESPONSE_TO_STATUSCODE: Final[dict[str, constants.StatusCode]] = {
         hislip.LOCKRESPONSE[0]: constants.StatusCode.error_resource_locked,
         hislip.LOCKRESPONSE[1]: constants.StatusCode.success,
@@ -216,7 +212,7 @@ class TCPIPInstrHiSLIP(Session):
                 f"on port {port} with lan device name {sub_address}"
             )
             raise OpenError() from e
-        
+
         # initialize the constant attributes
         self.attrs[ResourceAttribute.dma_allow_enabled] = constants.VI_FALSE
         self.attrs[ResourceAttribute.file_append_enabled] = constants.VI_FALSE
@@ -253,12 +249,12 @@ class TCPIPInstrHiSLIP(Session):
             self.get_keepalive,
             self.set_keepalive,
         )
-        
+
         # and now handle the lock
         if self.access_mode & constants.AccessModes.exclusive_lock:
             # It wouldn't be too hard to implement shared locking, since
             # the interface likely supports it, but for now we only handle exclusive locks.
-            
+
             # about the timeout: Found nothing in the spec that says how to handle this.
             # Do what is done by VXI-11
             lock_timeout = calculate_lock_timeout_from_open_timeout(self.open_timeout)
@@ -449,7 +445,7 @@ class TCPIPInstrHiSLIP(Session):
         errorcode = StatusCode.success
 
         return stb, errorcode
-    
+
     def lock(
         self,
         lock_type: constants.Lock,
@@ -491,8 +487,10 @@ class TCPIPInstrHiSLIP(Session):
         # Note to future: requested_key None is invalid: make it an empty string
         rv = self.interface.async_lock_request(timeout, "")
         # rv is from LOCKRESPONSE
-        
-        return "", self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
+
+        return "", self.LOCKRESPONSE_TO_STATUSCODE.get(
+            rv, StatusCode.error_nonsupported_operation
+        )
 
     def unlock(self) -> constants.StatusCode:
         """Relinquish a lock for the specified resource.
@@ -507,7 +505,9 @@ class TCPIPInstrHiSLIP(Session):
         """
         rv = self.interface.async_lock_release("")
         # rv is from LOCKRESPONSE
-        return self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
+        return self.LOCKRESPONSE_TO_STATUSCODE.get(
+            rv, StatusCode.error_nonsupported_operation
+        )
 
     def terminate(self, job_id: VISAJobID | None = None) -> StatusCode:
         """Cancel a pending I/O operation on this session.
@@ -777,7 +777,9 @@ class TCPIPInstrVxi11(Session):
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
 
         if lock_device:
-            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_EXCLUSIVE_LOCK
+            self.attrs[ResourceAttribute.resource_lock_state] = (
+                constants.VI_EXCLUSIVE_LOCK
+            )
         else:
             self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
 
@@ -1293,7 +1295,9 @@ class TCPIPInstrVxi11(Session):
         error = self.interface.device_lock(self.link, flags, timeout)
         error = vxi11_error_to_visa(error)
         if error == StatusCode.success:
-            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_EXCLUSIVE_LOCK
+            self.attrs[ResourceAttribute.resource_lock_state] = (
+                constants.VI_EXCLUSIVE_LOCK
+            )
 
         return "", error
 

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -23,6 +23,7 @@ from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
 from pyvisa.typing import VISAJobID
 
 from .common import LOGGER, int_to_byte
+from .events import EventContext
 from .protocols import hislip, rpc, vxi11
 from .sessions import OpenError, Session, UnknownAttribute, VISARMSession
 
@@ -135,16 +136,19 @@ class TCPIPInstrHiSLIP(Session):
     def after_parsing(self) -> None:
         # TODO: board_number not handled
 
-        if "," in self.parsed.lan_device_name:
-            sub_address, port_str = self.parsed.lan_device_name.split(",")
+        parsed = cast(rname.TCPIPInstr, self.parsed)
+
+        if "," in parsed.lan_device_name:
+            sub_address, port_str = parsed.lan_device_name.split(",")
             port = int(port_str)
         else:
-            sub_address = self.parsed.lan_device_name
+            sub_address = parsed.lan_device_name
             port = 4880
 
         try:
+            self._async_interrupted_message_id = None
             self.interface = hislip.Instrument(
-                self.parsed.host_address,
+                parsed.host_address,
                 open_timeout=(
                     self.open_timeout * 1000.0
                     if self.open_timeout is not None
@@ -153,10 +157,12 @@ class TCPIPInstrHiSLIP(Session):
                 timeout=self.timeout,
                 port=port,
                 sub_address=sub_address,
+                event_callback=self._handle_async_service_request,
+                interrupt_callback=self._handle_async_interrupted,
             )
         except Exception as e:
             LOGGER.exception(
-                f"Failed to open HiSLIP connection to {self.parsed.host_address} "
+                f"Failed to open HiSLIP connection to {parsed.host_address} "
                 f"on port {port} with lan device name {sub_address}"
             )
             raise OpenError() from e
@@ -173,11 +179,11 @@ class TCPIPInstrHiSLIP(Session):
         self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
         self.attrs[ResourceAttribute.send_end_enabled] = constants.VI_TRUE
         self.attrs[ResourceAttribute.suppress_end_enabled] = constants.VI_FALSE
-        self.attrs[ResourceAttribute.tcpip_address] = self.parsed.host_address
-        self.attrs[ResourceAttribute.tcpip_device_name] = self.parsed.lan_device_name
+        self.attrs[ResourceAttribute.tcpip_address] = parsed.host_address
+        self.attrs[ResourceAttribute.tcpip_device_name] = parsed.lan_device_name
         self.attrs[ResourceAttribute.tcpip_hislip_overlap_enable] = constants.VI_FALSE
         self.attrs[ResourceAttribute.tcpip_hislip_version] = 0x0010_0000
-        self.attrs[ResourceAttribute.tcpip_hostname] = self.parsed.host_address
+        self.attrs[ResourceAttribute.tcpip_hostname] = parsed.host_address
         self.attrs[ResourceAttribute.tcpip_is_hislip] = constants.VI_TRUE
         self.attrs[ResourceAttribute.tcpip_nodelay] = constants.VI_TRUE
         self.attrs[ResourceAttribute.tcpip_port] = port
@@ -196,6 +202,16 @@ class TCPIPInstrHiSLIP(Session):
             self.get_keepalive,
             self.set_keepalive,
         )
+
+    def _handle_async_service_request(self, status_byte: int) -> None:
+        ctx = EventContext(
+            event_type=constants.EventType.service_request,
+            context_id=status_byte,
+        )
+        self._fire_event(constants.EventType.service_request, ctx)
+
+    def _handle_async_interrupted(self, message_id: int) -> None:
+        self._async_interrupted_message_id = message_id
 
         # TODO: additional attributes (someday)
         # self.attrs[ResourceAttribute.manufacturer_id] = 16711

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -16,7 +16,7 @@ import socket
 import threading
 import time
 import warnings
-from typing import Any, Dict, Final, List, Optional, Tuple, Type, cast
+from typing import Any, Dict, Final, List, Optional, Tuple, Type
 
 from pyvisa import attributes, constants, errors, rname
 from pyvisa.constants import BufferOperation, ResourceAttribute, StatusCode
@@ -73,6 +73,22 @@ def vxi11_error_to_visa(error_code: int) -> StatusCode:
     VISA has no standard status code for them.
     """
     return VXI11_ERRORS_TO_VISA.get(int(error_code), StatusCode.error_io)
+
+
+def calculate_lock_timeout_from_open_timeout(open_timeout: Optional[int]) -> int:
+    # lock_timeout can be 0 for immediate
+    lock_timeout = open_timeout
+    if lock_timeout is None:
+        lock_timeout = (
+            10000  # default lock timeout in ms. This shouldn't happen
+        )
+    if lock_timeout == constants.VI_TMO_INFINITE:
+        lock_timeout = (
+            2**32 - 1
+        )  # This is dangerous, but hey, the caller wanted it.
+    if lock_timeout == constants.VI_TMO_IMMEDIATE:
+        lock_timeout = 0  # This is NOP, but makes the code more readable
+    return lock_timeout
 
 
 @Session.register(constants.InterfaceType.tcpip, "INSTR")
@@ -210,7 +226,8 @@ class TCPIPInstrHiSLIP(Session):
         self.attrs[ResourceAttribute.read_buffer_operation_mode] = (
             constants.VI_FLUSH_DISABLE
         )
-        self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
+        # do NOT set the resource lock state manually; it will be managed by the remote locking mechanism.
+        # self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
         self.attrs[ResourceAttribute.send_end_enabled] = constants.VI_TRUE
         self.attrs[ResourceAttribute.suppress_end_enabled] = constants.VI_FALSE
         self.attrs[ResourceAttribute.tcpip_address] = parsed.host_address
@@ -243,9 +260,9 @@ class TCPIPInstrHiSLIP(Session):
             # the interface likely supports it, but for now we only handle exclusive locks.
             
             # about the timeout: Found nothing in the spec that says how to handle this.
-            if self.timeout is None:
-                self.timeout = 10.0  # default timeout in seconds
-            k, rv = self.lock(constants.Lock.exclusive, int(1e3 * self.timeout), "")
+            # Do what is done by VXI-11
+            lock_timeout = calculate_lock_timeout_from_open_timeout(self.open_timeout)
+            k, rv = self.lock(constants.Lock.exclusive, lock_timeout, "")
             if rv != StatusCode.success:
                 raise RuntimeError("Failed to acquire exclusive lock")
 
@@ -399,8 +416,7 @@ class TCPIPInstrHiSLIP(Session):
             # unknown value?
             return StatusCode.error_nonsupported_operation
 
-        interface = cast(hislip.Instrument, self.interface)
-        interface.async_remote_local_control(method)
+        self.interface.async_remote_local_control(method)
 
         return StatusCode.success
 
@@ -428,9 +444,8 @@ class TCPIPInstrHiSLIP(Session):
 
         """
 
-        interface = cast(hislip.Instrument, self.interface)
         # According to IVI-6.1 Rev.2 status query corresponds to viReadSTB.
-        stb = interface.async_status_query()
+        stb = self.interface.async_status_query()
         errorcode = StatusCode.success
 
         return stb, errorcode
@@ -477,7 +492,6 @@ class TCPIPInstrHiSLIP(Session):
         rv = self.interface.async_lock_request(timeout, "")
         # rv is from LOCKRESPONSE
         
-        # TODO: look how to maintain self.attrs[ResourceAttribute.resource_lock_state]
         return "", self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
 
     def unlock(self) -> constants.StatusCode:
@@ -493,7 +507,6 @@ class TCPIPInstrHiSLIP(Session):
         """
         rv = self.interface.async_lock_release("")
         # rv is from LOCKRESPONSE
-        # TODO: look how to maintain self.attrs[ResourceAttribute.resource_lock_state]        
         return self.LOCKRESPONSE_TO_STATUSCODE.get(rv, StatusCode.error_nonsupported_operation)
 
     def terminate(self, job_id: VISAJobID | None = None) -> StatusCode:
@@ -529,8 +542,7 @@ class TCPIPInstrHiSLIP(Session):
             Return value of the library call.
 
         """
-        interface = cast(hislip.Instrument, self.interface)
-        interface.terminate()
+        self.interface.terminate()
         return StatusCode.success
 
     def _get_attribute(self, attribute: ResourceAttribute) -> Tuple[Any, StatusCode]:
@@ -551,6 +563,22 @@ class TCPIPInstrHiSLIP(Session):
             Return value of the library call.
 
         """
+        # get the lock state from the instrument itself:
+        # RULE 3.6.6
+        # IF a session uses HiSLIP, THEN a VISA implementation SHALL return the HiSLIP remote lock state
+        # for VI_ATTR_RSRC_LOCK_STATE.
+        if attribute == constants.VI_ATTR_RSRC_LOCK_STATE:
+            exclusive_lock = self.interface.async_lock_info()
+            # exclusive_lock: 0 – No exclusive lock granted
+            #                 1 – Exclusive lock granted
+            # we do not do shared locks (yet)
+            if exclusive_lock not in (0, 1):
+                raise ValueError(f"Unexpected exclusive_lock value: {exclusive_lock}")
+            else:
+                if exclusive_lock == 0:
+                    return constants.VI_NO_LOCK, StatusCode.success
+                else:
+                    return constants.VI_EXCLUSIVE_LOCK, StatusCode.success
         raise UnknownAttribute(attribute)
 
     def _set_attribute(
@@ -725,19 +753,7 @@ class TCPIPInstrVxi11(Session):
 
         if self.access_mode & constants.AccessModes.exclusive_lock:
             lock_device = 1
-            # The below is for lock_timeout, the instrument has been opened already
-            # lock_timeout can be 0 for immediate
-            lock_timeout = self.open_timeout
-            if lock_timeout is None:
-                lock_timeout = (
-                    10000  # default lock timeout in ms. This shouldn't happen
-                )
-            if lock_timeout == constants.VI_TMO_INFINITE:
-                lock_timeout = (
-                    2**32 - 1
-                )  # This is dangerous, but hey, the caller wanted it.
-            if lock_timeout == constants.VI_TMO_IMMEDIATE:
-                lock_timeout = 0  # This is NOP, but makes the code more readable
+            lock_timeout = calculate_lock_timeout_from_open_timeout(self.open_timeout)
         else:
             lock_device = 0
             lock_timeout = 0  # time is not used now.
@@ -759,6 +775,11 @@ class TCPIPInstrVxi11(Session):
         for name in ("SEND_END_EN", "TERMCHAR", "TERMCHAR_EN", "SUPPRESS_END_EN"):
             attribute = getattr(constants, "VI_ATTR_" + name)
             self.attrs[attribute] = attributes.AttributesByID[attribute].default
+
+        if lock_device:
+            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_EXCLUSIVE_LOCK
+        else:
+            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
 
         # add the Keysight and PyVISA-Py specific lock wait attribute, which is a boolean that
         # controls whether to wait for the lock or not
@@ -1270,8 +1291,11 @@ class TCPIPInstrVxi11(Session):
             flags = vxi11.OP_FLAG_WAIT_BLOCK
 
         error = self.interface.device_lock(self.link, flags, timeout)
+        error = vxi11_error_to_visa(error)
+        if error == StatusCode.success:
+            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_EXCLUSIVE_LOCK
 
-        return "", vxi11_error_to_visa(error)
+        return "", error
 
     def unlock(self) -> constants.StatusCode:
         """Relinquish a lock for the specified resource.
@@ -1285,8 +1309,11 @@ class TCPIPInstrVxi11(Session):
 
         """
         error = self.interface.device_unlock(self.link)
+        error = vxi11_error_to_visa(error)
+        if error == StatusCode.success:
+            self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
 
-        return vxi11_error_to_visa(error)
+        return error
 
     def _set_timeout(self, attribute: ResourceAttribute, value: int) -> StatusCode:
         """Sets timeout calculated value from python way to VI_ way"""

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -112,7 +112,7 @@ class TCPIPInstrHiSLIP(Session):
     # want it to be registered in the _session_classes array, but we still
     # need to define session_type to make the set_attribute machinery work.
     session_type = (constants.InterfaceType.tcpip, "INSTR")
-    
+
     _supported_event_types = {constants.EventType.service_request}
 
     # Override parsed to take into account the fact that this class is only used

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -222,8 +222,7 @@ class TCPIPInstrHiSLIP(Session):
         self.attrs[ResourceAttribute.read_buffer_operation_mode] = (
             constants.VI_FLUSH_DISABLE
         )
-        # do NOT set the resource lock state manually; it will be managed by the remote locking mechanism.
-        # self.attrs[ResourceAttribute.resource_lock_state] = constants.VI_NO_LOCK
+        # do NOT set the resource_lock_state manually; it will be managed by the remote locking mechanism.
         self.attrs[ResourceAttribute.send_end_enabled] = constants.VI_TRUE
         self.attrs[ResourceAttribute.suppress_end_enabled] = constants.VI_FALSE
         self.attrs[ResourceAttribute.tcpip_address] = parsed.host_address

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -274,7 +274,6 @@ class TCPIPInstrHiSLIP(Session):
         # self.attrs[ResourceAttribute.user_data] = 0
         # self.attrs[ResourceAttribute.write_buffer_size] = 4096
 
-
     def _handle_async_service_request(self, status_byte: int) -> None:
         ctx = EventContext(
             event_type=constants.EventType.service_request,

--- a/pyvisa_py/tcpip.py
+++ b/pyvisa_py/tcpip.py
@@ -263,16 +263,6 @@ class TCPIPInstrHiSLIP(Session):
                 self.close()  # the operation was open_with_lock. If the lock fails, the open should also be reversed.
                 raise RuntimeError("Failed to acquire exclusive lock")
 
-    def _handle_async_service_request(self, status_byte: int) -> None:
-        ctx = EventContext(
-            event_type=constants.EventType.service_request,
-            context_id=status_byte,
-        )
-        self._fire_event(constants.EventType.service_request, ctx)
-
-    def _handle_async_interrupted(self, message_id: int) -> None:
-        self._async_interrupted_message_id = message_id
-
         # TODO: additional attributes (someday)
         # self.attrs[ResourceAttribute.manufacturer_id] = 16711
         # self.attrs[ResourceAttribute.max_queue_length] = 50
@@ -283,6 +273,7 @@ class TCPIPInstrHiSLIP(Session):
         # self.attrs[ResourceAttribute.resource_spec_version] = 0x0050_0800
         # self.attrs[ResourceAttribute.user_data] = 0
         # self.attrs[ResourceAttribute.write_buffer_size] = 4096
+
 
     def _handle_async_service_request(self, status_byte: int) -> None:
         ctx = EventContext(

--- a/pyvisa_py/testsuite/test_hislip_terminate.py
+++ b/pyvisa_py/testsuite/test_hislip_terminate.py
@@ -192,6 +192,104 @@ class TestHiSLIPInterruptedInHeader:
         assert header.message_parameter == 0xFFFF_FF00
 
 
+class TestAsyncChannelDispatcher:
+    """Test the background async reader and request dispatcher."""
+
+    def _make_hislip_header(
+        self,
+        msg_type: str,
+        control_code: int,
+        message_parameter: int,
+        payload_length: int,
+    ) -> bytes:
+        return struct.pack(
+            HEADER_FORMAT,
+            b"HS",
+            MESSAGETYPE[msg_type],
+            control_code,
+            message_parameter,
+            payload_length,
+        )
+
+    def test_async_service_request_fires_callback(self):
+        from pyvisa_py.protocols.hislip import AsyncChannel
+
+        server, client_raw = socket.socketpair()
+        events = []
+        channel = AsyncChannel(client_raw, event_callback=events.append)
+        channel.start()
+
+        server.sendall(self._make_hislip_header("AsyncServiceRequest", 0x42, 0, 0))
+
+        deadline = time.time() + 2.0
+        while not events and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert events == [0x42]
+
+        channel.close()
+        server.close()
+
+    def test_async_request_gets_dispatcher_response(self):
+        from pyvisa_py.protocols.hislip import AsyncChannel
+
+        server, client_raw = socket.socketpair()
+        channel = AsyncChannel(client_raw)
+        channel.start()
+
+        result = {}
+
+        def responder():
+            request_header = server.recv(1024)
+            assert request_header
+            response_header = self._make_hislip_header(
+                "AsyncStatusResponse", 0x5A, 0, 0
+            )
+            server.sendall(response_header)
+
+        responder_thread = threading.Thread(target=responder)
+        responder_thread.start()
+
+        result["response"] = channel.request(
+            "AsyncStatusQuery", 0, 0, expected_response="AsyncStatusResponse"
+        )
+
+        responder_thread.join(timeout=2.0)
+        assert not responder_thread.is_alive()
+        assert result["response"].msg_type == "AsyncStatusResponse"
+        assert result["response"].control_code == 0x5A
+
+        channel.close()
+        server.close()
+
+    def test_async_interrupted_aborts_pending_request(self):
+        from pyvisa_py.protocols.hislip import AsyncChannel
+
+        server, client_raw = socket.socketpair()
+        channel = AsyncChannel(client_raw)
+        channel.start()
+
+        def responder():
+            request_header = server.recv(1024)
+            assert request_header
+            server.sendall(self._make_hislip_header("AsyncInterrupted", 0, 0xBEEF, 0))
+
+        responder_thread = threading.Thread(target=responder)
+        responder_thread.start()
+
+        with pytest.raises(HiSLIPInterruptedError) as excinfo:
+            channel.request(
+                "AsyncStatusQuery", 0, 0, expected_response="AsyncStatusResponse"
+            )
+
+        responder_thread.join(timeout=2.0)
+        assert not responder_thread.is_alive()
+        assert excinfo.value.message_id == 0xBEEF
+
+        channel.close()
+        server.close()
+
+
 class TestInstrumentTerminate:
     """Test Instrument.terminate() and complete_terminate() via mocking."""
 
@@ -385,6 +483,30 @@ class TestTCPIPInstrHiSLIPTerminate:
         data, status = sess.read(4)
         assert data == b"abcd"
         assert status == StatusCode.success_max_count_read
+
+    def test_async_service_request_callback_fires_event(self):
+        from pyvisa import constants
+        from pyvisa_py.events import EventContext
+        from pyvisa_py.tcpip import TCPIPInstrHiSLIP
+
+        sess = object.__new__(TCPIPInstrHiSLIP)
+        sess._fire_event = MagicMock()
+
+        TCPIPInstrHiSLIP._handle_async_service_request(sess, 0x44)
+
+        sess._fire_event.assert_called_once()
+        event_type, ctx = sess._fire_event.call_args.args
+        assert event_type == constants.EventType.service_request
+        assert isinstance(ctx, EventContext)
+        assert ctx.context_id == 0x44
+
+    def test_async_interrupted_callback_stores_message_id(self):
+        from pyvisa_py.tcpip import TCPIPInstrHiSLIP
+
+        sess = object.__new__(TCPIPInstrHiSLIP)
+        sess._handle_async_interrupted(0x1234)
+
+        assert sess._async_interrupted_message_id == 0x1234
 
 
 class TestHighlevelTerminate:

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -206,4 +206,3 @@ def test_open_hislip_with_exclusive_lock_failure_closes_connection():
 
     mock_instrument.async_lock_request.assert_called_once()
     mock_instrument.close.assert_called_once()
-

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -184,5 +184,3 @@ def test_hislip_lock_updates_resource_lock_state():
 
     state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
     assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
-
-

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -1,4 +1,4 @@
-"""Tests for opening VXI-11 resources."""
+"""Tests for locking resources."""
 
 from unittest.mock import ANY, MagicMock, patch
 
@@ -6,7 +6,7 @@ import pytest
 
 from pyvisa import constants, errors, rname
 from pyvisa_py import highlevel
-from pyvisa_py.tcpip import TCPIPInstrVxi11
+from pyvisa_py.tcpip import TCPIPInstrHiSLIP, TCPIPInstrVxi11
 
 
 @pytest.mark.parametrize(
@@ -132,8 +132,57 @@ def test_highlevel_lock_sets_vxi11_device_lock_flags_and_timeout(
         client.device_lock.assert_not_called()
         return
 
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
+
     key, status = library.lock(1, lock_type, timeout)
 
     assert key == ""
     assert status == constants.StatusCode.success
     client.device_lock.assert_called_once_with(session.link, expected_flags, timeout)
+
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (
+        constants.VI_EXCLUSIVE_LOCK,
+        constants.StatusCode.success,
+    )
+
+    client.device_unlock.return_value = 0
+    assert library.unlock(1) == constants.StatusCode.success
+    client.device_unlock.assert_called_once_with(session.link)
+
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
+
+
+def test_hislip_lock_updates_resource_lock_state():
+    session = object.__new__(TCPIPInstrHiSLIP)
+    session.attrs = {}
+    session.interface = MagicMock()
+    session.interface.async_lock_info.side_effect = [0, 1, 0]
+    session.interface.async_lock_request.return_value = "success"
+    session.interface.async_lock_release.return_value = "success"
+
+    library = highlevel.PyVisaLibrary()
+    library.sessions = {1: session}
+
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
+
+    key, status = library.lock(1, constants.Lock.exclusive, 1000)
+    assert (key, status) == ("", constants.StatusCode.success)
+    session.interface.async_lock_request.assert_called_once_with(1000, "")
+
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (
+        constants.VI_EXCLUSIVE_LOCK,
+        constants.StatusCode.success,
+    )
+
+    assert library.unlock(1) == constants.StatusCode.success
+    session.interface.async_lock_release.assert_called_once_with("")
+
+    state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
+    assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
+
+

--- a/pyvisa_py/testsuite/test_locks.py
+++ b/pyvisa_py/testsuite/test_locks.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from pyvisa import constants, errors, rname
+from pyvisa.typing import VISARMSession
 from pyvisa_py import highlevel
 from pyvisa_py.tcpip import TCPIPInstrHiSLIP, TCPIPInstrVxi11
 
@@ -184,3 +185,25 @@ def test_hislip_lock_updates_resource_lock_state():
 
     state, status = library.get_attribute(1, constants.VI_ATTR_RSRC_LOCK_STATE)
     assert (state, status) == (constants.VI_NO_LOCK, constants.StatusCode.success)
+
+
+def test_open_hislip_with_exclusive_lock_failure_closes_connection():
+    resource_name = "TCPIP::localhost::hislip0::INSTR"
+    parsed = rname.parse_resource_name(resource_name)
+    mock_instrument = MagicMock()
+    # Return a response that indicates lock request failure
+    mock_instrument.async_lock_request.return_value = "failure"
+
+    with patch("pyvisa_py.tcpip.hislip.Instrument", return_value=mock_instrument):
+        with pytest.raises(RuntimeError, match="Failed to acquire exclusive lock"):
+            TCPIPInstrHiSLIP(
+                VISARMSession(1),
+                resource_name,
+                parsed,
+                access_mode=constants.AccessModes.exclusive_lock,
+                open_timeout=1000,
+            )
+
+    mock_instrument.async_lock_request.assert_called_once()
+    mock_instrument.close.assert_called_once()
+


### PR DESCRIPTION
Preparing, this is to be applied AFTER #626 

- [x] Closes #635
- [x] Executed ``pre-commit`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
